### PR TITLE
copy in relevant NEWS files to outputs from relevant PACTA pkgs

### DIFF
--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -847,6 +847,21 @@ pacta.data.preparation:::write_manifest(
 )
 
 
+# copy in NEWs.md files from relevant PACTA packages ---------------------------
+
+pkg_name <- "pacta.data.preparation"
+file.copy(
+  system.file("NEWS.md", package = pkg_name), 
+  to = file.path(data_prep_outputs_path, paste0(pkg_name, "-NEWS.md"))
+)
+
+pkg_name <- "pacta.scenario.preparation"
+file.copy(
+  system.file("NEWS.md", package = pkg_name), 
+  to = file.path(data_prep_outputs_path, paste0(pkg_name, "-NEWS.md"))
+)
+
+
 # ------------------------------------------------------------------------------
 
 log_info("PACTA Data Preparation Complete.")


### PR DESCRIPTION
closes #5
related ADO-6159

Copies the NEWS.md files from the relevant PACTA pkgs into the output directory so there is a human friendly record of the recent changes made in those pkgs.