### PR TITLE
Revert to an old version of masterdata_debt

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -30,7 +30,7 @@ default:
 
 2021Q4:
   masterdata_ownership_filename: "2022-08-15_rmi_masterdata_ownership_2021q4.csv"
-  masterdata_debt_filename: "2023-01-13_rmi_masterdata_debt_2021q4.csv"
+  masterdata_debt_filename: "2022-10-05_rmi_masterdata_debt_2021q4.csv"
   ar_company_id__factset_entity_id_filename: "2022-08-17_rmi_ar_fs_id_bridge_2021q4.csv"
   imf_quarter_timestamp: "2021-Q4"
   factset_data_timestamp: "2021-12-31"


### PR DESCRIPTION
I am just using this PR to keep track of any changes I make for this run of data prep. 
I don't think we should necessarily merge it, I just wanted visibility. 

Relates to: https://dev.azure.com/RMI-PACTA/2DegreesInvesting/_workitems/edit/6321
Relates to https://dev.azure.com/RMI-PACTA/2DegreesInvesting/_workitems/edit/6324