### PR TITLE
Add `tdm_years` concept to data preparation

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -15,6 +15,7 @@ default:
   indices_timestamp: "20211231"
   market_share_target_reference_year: 2021
   time_horizon: 5
+  tdm_delta_years: [5, 10]
   additional_year: [2030, 2040]
   scenario_sources_list: ["ETP2020", "GECO2021", "IPR2021", "ISF2021", "WEO2021"]
   sector_list: ["Automotive", "Power", "Fossil Fuels", "Oil&Gas", "Coal"]
@@ -38,6 +39,7 @@ default:
   indices_timestamp: "20211231"
   market_share_target_reference_year: 2021
   time_horizon: 5
+  tdm_delta_years: [5, 10]
   additional_year: [2030, 2040]
   scenario_sources_list: ["ETP2020", "GECO2021", "IPR2021", "ISF2021", "WEO2021"]
   sector_list: ["Automotive", "Power", "Fossil Fuels", "Oil&Gas", "Coal"]
@@ -70,6 +72,7 @@ default:
   indices_timestamp: "20220630"
   market_share_target_reference_year: 2022
   time_horizon: 5
+  tdm_delta_years: [5, 10]
   additional_year: [2030, 2040]
   scenario_sources_list: ["ETP2020", "GECO2021", "IPR2021", "ISF2021", "WEO2021"]
   sector_list: ["Automotive", "Power", "Fossil Fuels", "Oil&Gas", "Coal"]

--- a/config.yml
+++ b/config.yml
@@ -39,7 +39,6 @@ default:
   indices_timestamp: "20211231"
   market_share_target_reference_year: 2021
   time_horizon: 5
-  tdm_delta_years: [5, 10]
   additional_year: [2030, 2040]
   scenario_sources_list: ["ETP2020", "GECO2021", "IPR2021", "ISF2021", "WEO2021"]
   sector_list: ["Automotive", "Power", "Fossil Fuels", "Oil&Gas", "Coal"]
@@ -72,7 +71,6 @@ default:
   indices_timestamp: "20220630"
   market_share_target_reference_year: 2022
   time_horizon: 5
-  tdm_delta_years: [5, 10]
   additional_year: [2030, 2040]
   scenario_sources_list: ["ETP2020", "GECO2021", "IPR2021", "ISF2021", "WEO2021"]
   sector_list: ["Automotive", "Power", "Fossil Fuels", "Oil&Gas", "Coal"]

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -90,6 +90,7 @@ relevant_years <- sort(
   unique(
     c(
       market_share_target_reference_year:(market_share_target_reference_year + time_horizon),
+      market_share_target_reference_year + tdm_delta_years,
       additional_year
     )
   )
@@ -290,7 +291,7 @@ scenario_regions <- readr::read_csv(scenario_regions_path, na = "", show_col_typ
 
 index_regions <- pacta.data.scraping::get_index_regions()
 
-factset_issue_code_bridge <- 
+factset_issue_code_bridge <-
   pacta.data.preparation::factset_issue_code_bridge %>%
   select(issue_type_code, asset_type) %>%
   mutate(
@@ -303,7 +304,7 @@ factset_issue_code_bridge <-
     )
   )
 
-factset_industry_map_bridge <- 
+factset_industry_map_bridge <-
   pacta.data.preparation::factset_industry_map_bridge %>%
   select(factset_industry_code, pacta_sector)
 


### PR DESCRIPTION
This PR:
* Adds a new parameter, `tdm_delta_years`, to the `config.yml`, which indicates any extra years that scenario targets need be calculated for, to be used in the TDM. These years are "deltas" meaning a duration, as measured from the start year (rather than a fixed value)
* Adds these new years to the `run_pacta_data_preparation` script

What this PR does NOT do: Test if those years are even present in any of the scenario data!!

Relates to https://github.com/RMI-PACTA/pacta.portfolio.analysis/issues/219

Closes #31