### PR TITLE
add pacta.data.scraping as non-CRAN dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ WORKDIR /workflow.data.preparation
 
 RUN Rscript -e '\
   readRenviron(".env"); \
-  private_pkgs <- c("RMI-PACTA/pacta.scenario.preparation", "RMI-PACTA/pacta.data.preparation"); \
-  script_dep_pkgs <- setdiff(renv::dependencies()$Package, basename(private_pkgs)); \
+  non_cran_pkgs <- c("RMI-PACTA/pacta.scenario.preparation", "RMI-PACTA/pacta.data.preparation", "RMI-PACTA/pacta.data.scraping"); \
+  script_dep_pkgs <- setdiff(renv::dependencies()$Package, basename(non_cran_pkgs)); \
   pak::pkg_install("tidyverse/dbplyr"); \
-  pak::pkg_install(pkg = c(private_pkgs, script_dep_pkgs)); \
+  pak::pkg_install(pkg = c(non_cran_pkgs, script_dep_pkgs)); \
   '
 
 CMD Rscript run_pacta_data_preparation.R


### PR DESCRIPTION
#27 added pacta.data.scraping as a dependency but didn't add it to the list of non-CRAN package dependencies in the Dockerfile