### PR TITLE
Use new dataset `scenario_source_pacta_geography_bridge` to bridge scenario region names

### DIFF
--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -259,6 +259,15 @@ scenario_raw <- readr::read_csv(scenarios_analysis_input_path, show_col_types = 
 
 # filter for relevant scenario data
 scenarios_long <- scenario_raw %>%
+  inner_join(
+    pacta.scenario.preparation::scenario_source_pacta_geography_bridge,
+    by = c(
+      scenario_source = "source",
+      scenario_geography = "scenario_geography_source"
+      )
+    ) %>%
+  select(-scenario_geography) %>%
+  rename(scenario_geography = "scenario_geography_pacta") %>%
   filter(
     .data$scenario_source %in% .env$scenario_sources_list,
     .data$ald_sector %in% c(.env$sector_list, .env$other_sector_list),

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -262,11 +262,11 @@ scenarios_long <- scenario_raw %>%
   inner_join(
     pacta.scenario.preparation::scenario_source_pacta_geography_bridge,
     by = c(
-      scenario_source = "source",
-      scenario_geography = "scenario_geography_source"
+      .data$scenario_source = "source",
+      .data$scenario_geography = "scenario_geography_source"
       )
     ) %>%
-  select(-scenario_geography) %>%
+  select(-.data$scenario_geography) %>%
   rename(scenario_geography = "scenario_geography_pacta") %>%
   filter(
     .data$scenario_source %in% .env$scenario_sources_list,


### PR DESCRIPTION
This PR makes use of the newly defined `scenario_source_pacta_geography_bridge` to bridge the scenario-defined region names (e.g. IPR "WORLD") to the PACTA-compatible scenario name (e.g. "Global"). 

It does this using a dataset exported by the pacta.scenario.preparation package. 

Currently the only regions defined and managed are "Global", "OECD" and "NonOECD". 
The only scenarios this applies to are "ETP2020", "GECO2021", "ISF2021", "WEO2021", and "IPR2021".

Prior to adding new scenarios to Transition Monitor, we will need to update this list. 

Depends on https://github.com/RMI-PACTA/pacta.scenario.preparation/pull/91