### PR TITLE
Remove unnecessary .data pronoun

### DIFF
--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -262,8 +262,8 @@ scenarios_long <- scenario_raw %>%
   inner_join(
     pacta.scenario.preparation::scenario_source_pacta_geography_bridge,
     by = c(
-      .data$scenario_source = "source",
-      .data$scenario_geography = "scenario_geography_source"
+      scenario_source = "source",
+      scenario_geography = "scenario_geography_source"
       )
     ) %>%
   select(-.data$scenario_geography) %>%


### PR DESCRIPTION
join needs a named vector, not a `.data$` pronoun. 