### PR TITLE
Remove deprecated use of `.data$` in tidyselect functions

### DIFF
--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -266,7 +266,7 @@ scenarios_long <- scenario_raw %>%
       scenario_geography = "scenario_geography_source"
       )
     ) %>%
-  select(-.data$scenario_geography) %>%
+  select("scenario_geography") %>%
   rename(scenario_geography = "scenario_geography_pacta") %>%
   filter(
     .data$scenario_source %in% .env$scenario_sources_list,


### PR DESCRIPTION
This will always confuse me. But tidyselect prefers quoted names over the `.data` pronoun.