### PR TITLE
Add missing `-` sign to call to `select()`

### DIFF
--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -266,7 +266,7 @@ scenarios_long <- scenario_raw %>%
       scenario_geography = "scenario_geography_source"
       )
     ) %>%
-  select("scenario_geography") %>%
+  select(-"scenario_geography") %>%
   rename(scenario_geography = "scenario_geography_pacta") %>%
   filter(
     .data$scenario_source %in% .env$scenario_sources_list,


### PR DESCRIPTION
Fixes a bug that I introduced in https://github.com/RMI-PACTA/workflow.data.preparation/pull/53