### PR TITLE
add infrastructure to run on VM instead of ACI

### DIFF
--- a/ACI/README.md
+++ b/ACI/README.md
@@ -25,8 +25,13 @@ Due to data prep requiring >16 GB of memory (which is the current limit for stan
 
 ```sh
 
-RESOURCEGROUP="pacta-experiments" \
-    ./deploy-vm.sh
+# must set envvar RESOURCEGROUP and refer to an exisitng Azure RG.
+# set inline
+# RESOURCEGROUP="<myRG>" ./deploy-vm.sh
+# or with export:
+# export RESOURCEGROUP="<myRG>"
+
+./deploy-vm.sh
 
 ```
 
@@ -38,11 +43,20 @@ You can connect to the VM if you first connect to the VPN (the deploy script doe
 
 ```sh
 
-RESOURCEGROUP="pacta-experiments" \
 az ssh vm \
     --local-user azureuser \
     --name "data-prep-runner" \
     --prefer-private-ip \
     --resource-group "$RESOURCEGROUP"
+
+```
+
+### Watching progress
+
+from an SSH session (above):
+
+```sh
+
+tmux new-session tail -n 10000 -f /var/log/cloud-init-output.log
 
 ```

--- a/ACI/README.md
+++ b/ACI/README.md
@@ -1,0 +1,48 @@
+# Docker image for running on Azure Container Instances
+
+## Build
+
+Because the docker image includes private repos, you must include a GITHUB PAT in the file `ACI/github_pat.txt` in order for the following command to work.
+
+```sh
+# Note that path to secretfile must be an absolute path 
+# or use $(pwd) if in working dir
+
+# must build with buildkit
+# run from repo root
+docker build \
+  --secret id=github_pat,src=$(pwd)/ACI/github_pat.txt \
+  --progress=plain \
+  --tag transitionmonitordockerregistry.azurecr.io/workflow.data.preparation_aci \
+  -f ACI/Dockerfile.ACI . 
+
+```
+
+## Running on Azure VM
+
+Due to data prep requiring >16 GB of memory (which is the current limit for standard ACI runners), `deploy-vm.sh` is a script that will initialize a virtual machine, mount the required file shares, and pull and run the docker container.
+**The docker image must exist on the continer registry before running the script.**
+
+```sh
+
+RESOURCEGROUP="pacta-experiments" \
+    ./deploy-vm.sh
+
+```
+
+**Please delete the VM when it's finished!**
+
+### Inpsecting the VMs
+
+You can connect to the VM if you first connect to the VPN (the deploy script does not create a public IP).
+
+```sh
+
+RESOURCEGROUP="pacta-experiments" \
+az ssh vm \
+    --local-user azureuser \
+    --name "data-prep-runner" \
+    --prefer-private-ip \
+    --resource-group "$RESOURCEGROUP"
+
+```

--- a/ACI/cloud-init.txt
+++ b/ACI/cloud-init.txt
@@ -1,0 +1,156 @@
+#cloud-config
+package_upgrade: false
+package_reboot_if_required: true
+
+# Timeout: https://stackoverflow.com/a/71408252
+apt:
+  conf: |
+    Acquire::Retries "60";
+    DPkg::Lock::Timeout "60";
+  sources:
+    # Needed to install azure-cli
+    microsoft:
+      # keyid comes from:
+      # curl  https://packages.microsoft.com/keys/microsoft.asc | gpg --with-fingerprint --with-colons | awk -F: '/^fpr/ { print $10 }'
+      # see: https://stackoverflow.com/a/72629066
+      keyid: "BC528686B50D79E339D3721CEB3E94ADBE1229CF"
+      source: "deb https://packages.microsoft.com/repos/azure-cli/ $RELEASE main"
+
+packages:
+    - azure-cli
+    - cifs-utils
+    - docker.io
+
+# create the docker group
+groups:
+    - docker
+
+# assign a VM's default user, which is mydefaultuser, to the docker group
+users:
+    - default
+    - name: azureuser
+      groups: docker, staff
+
+write_files:
+    - encoding: text/plain
+      content: |
+        #! /bin/sh
+        #  mount an Azure File Share at a given location.
+        #  Requires az cli to be installed and logged in.
+        usage() {
+            echo "Usage: mount_afs.sh [-h] [-v] -r <resource group> -a <storage account name> -f <file share name> -m <mount point>"
+            echo "  -h: help (this message)"
+            echo "  -v: verbose"
+            echo "  -r: resource group (Required)"
+            echo "  -a: storage account name (Required)"
+            echo "  -f: file share name (Required)"
+            echo "  -m: mount point (Required)"
+            echo "  -?: help"
+            exit 1
+        }
+        while getopts "h?vr:a:f:m:" opt; do
+            case "$opt" in
+            h|\?)
+                usage
+                ;;
+            v)  VERBOSE=1
+                ;;
+            r)  RESOURCEGROUP=$OPTARG
+                ;;
+            a)  STORAGEACCOUNTNAME=$OPTARG
+                ;;
+            f)  FILESHARENAME=$OPTARG
+                ;;
+            m)  MOUNTPOINT=$OPTARG
+                ;;
+            *)
+                usage
+                ;;
+            esac
+        done
+        missing_opts=0
+        if [ -z "$RESOURCEGROUP" ]; then
+            echo "ERROR: Resource group is required"
+            missing_opts=1
+        fi
+        if [ -z "$STORAGEACCOUNTNAME" ]; then
+            echo "ERROR: Storage account name is required"
+            missing_opts=1
+        fi
+        if [ -z "$FILESHARENAME" ]; then
+            echo "ERROR: File share name is required"
+            missing_opts=1
+        fi
+        if [ -z "$MOUNTPOINT" ]; then
+            echo "ERROR: Mount point is required"
+            missing_opts=1
+        fi
+        if [ $missing_opts -eq 1 ]; then
+            usage
+        fi
+        if [ -n "$VERBOSE" ]; then
+            echo "RESOURCEGROUP: $RESOURCEGROUP"
+            echo "STORAGEACCOUNTNAME: $STORAGEACCOUNTNAME"
+            echo "FILESHARENAME: $FILESHARENAME"
+            echo "MOUNTPOINT: $MOUNTPOINT"
+        fi
+        # This command assumes you have logged in with az login
+        if [ -n "$VERBOSE" ]; then
+            echo "Getting https endpoint for storage account $STORAGEACCOUNTNAME"
+        fi
+        httpEndpoint=$(az storage account show \
+          --resource-group "$RESOURCEGROUP" \
+          --name "$STORAGEACCOUNTNAME" \
+          --query "primaryEndpoints.file" --output tsv | tr -d '"')
+        smbPath=$(echo "$httpEndpoint" | cut -c7-${#httpEndpoint})$FILESHARENAME
+        fileHost=$(echo "$httpEndpoint" | cut -c7-${#httpEndpoint}| tr -d "/")
+        nc -zvw3 "$fileHost" 445
+        if [ -n "$VERBOSE" ]; then
+            echo "httpEndpoint: $httpEndpoint"
+            echo "smbPath: $smbPath"
+            echo "fileHost: $fileHost"
+        fi
+        if [ -n "$VERBOSE" ]; then
+            echo "Getting storage account key"
+        fi
+        storageAccountKey=$(az storage account keys list \
+          --resource-group "$RESOURCEGROUP" \
+          --account-name "$STORAGEACCOUNTNAME" \
+          --query "[0].value" --output tsv | tr -d '"')
+        if [ -n "$VERBOSE" ]; then
+            echo "Creating mount path: $MOUNTPOINT"
+        fi
+        sudo mkdir -p "$MOUNTPOINT"
+        if [ -n "$VERBOSE" ]; then
+            echo "Mounting $smbPath to $MOUNTPOINT"
+        fi
+        sudo mount -t cifs "$smbPath" "$MOUNTPOINT" -o username="$STORAGEACCOUNTNAME",password="$storageAccountKey",serverino,nosharesock,actimeo=30,file_mode=0777,nobrl,dir_mode=0777,vers=3.1.1
+      path: '/usr/local/bin/mount_afs'
+      permissions: '0755'
+    - encoding: text/plain
+      content: |
+        #! /bin/sh
+        az login --identity
+        mount_afs -v -r pacta-data -a pactarawdata -f factset-extracted -m /mnt/factset-extracted
+        mount_afs -v -r pacta-data -a pactarawdata -f rawdata -m /mnt/rawdata
+        mount_afs -v -r pacta-data -a pactadata -f data-prep-inputs -m /mnt/dataprep_inputs
+        mount_afs -v -r pacta-data -a pactadata -f data-prep-outputs -m /mnt/outputs
+        az acr login --name transitionmonitordockerregistry
+        DOCKERIMAGE="transitionmonitordockerregistry.azurecr.io/workflow.data.preparation_aci"
+        docker pull $DOCKERIMAGE
+        docker run \
+          -i -t --rm \
+          --env DEPLOY_START_TIME=$(date -u +%Y%m%dT%H%M%SZ) \
+          --env LOG_LEVEL=TRACE \
+          --env R_CONFIG_ACTIVE=2022Q4_CICD \
+          --mount type=bind,source=/mnt/dataprep_inputs,target=/mnt/dataprep_inputs \
+          --mount type=bind,source=/mnt/factset-extracted,target=/mnt/factset-extracted,readonly \
+          --mount type=bind,source=/mnt/outputs,target=/mnt/outputs \
+          --mount type=bind,source=/mnt/rawdata,target=/mnt/rawdata,readonly \
+          $DOCKERIMAGE
+      path: '/usr/local/bin/run_dataprep_docker'
+      permissions: '0755'
+
+runcmd:
+  - [chown, -R, azureuser, /home/azureuser]
+  - [su, -c, "run_dataprep_docker", azureuser]

--- a/ACI/cloud-init.txt
+++ b/ACI/cloud-init.txt
@@ -139,7 +139,6 @@ write_files:
         DOCKERIMAGE="transitionmonitordockerregistry.azurecr.io/workflow.data.preparation_aci"
         docker pull $DOCKERIMAGE
         docker run \
-          -i -t --rm \
           --env DEPLOY_START_TIME=$(date -u +%Y%m%dT%H%M%SZ) \
           --env LOG_LEVEL=TRACE \
           --env R_CONFIG_ACTIVE=2022Q4_CICD \
@@ -153,4 +152,4 @@ write_files:
 
 runcmd:
   - [chown, -R, azureuser, /home/azureuser]
-  - [su, -c, "run_dataprep_docker", azureuser]
+  - [su, -c, "/usr/local/bin/run_dataprep_docker", azureuser]

--- a/ACI/deploy-vm.sh
+++ b/ACI/deploy-vm.sh
@@ -1,0 +1,34 @@
+#! /bin/sh
+
+# check that RESOURCEGROUP is set
+if [ -z "$RESOURCEGROUP" ]; then
+    echo "envvar RESOURCEGROUP is not set"
+    exit 1
+fi
+
+SUBNETID=$(az network vnet subnet show --resource-group RMI-PROD-EU-VNET-RG --name Server --vnet-name RMI-PROD-EU-VNET --query id -o tsv)
+MACHINENAME="data-prep-runner"
+MACHINEIDENTITY="/subscriptions/feef729b-4584-44af-a0f9-4827075512f9/resourceGroups/pacta-experiments/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ACR-test-01"
+MACHINESIZE="Standard_E4-2as_v4"
+
+if [ -n "$DEBUG" ]; then
+    echo "MACHINEIDENTITY: $MACHINEIDENTITY"
+    echo "MACHINENAME: $MACHINENAME"
+    echo "MACHINESIZE: $MACHINESIZE"
+    echo "RESOURCEGROUP: $RESOURCEGROUP"
+    echo "SUBNETID: $SUBNETID"
+fi
+
+az vm create \
+  --resource-group "$RESOURCEGROUP" \
+  --name "$MACHINENAME" \
+  --image Ubuntu2204 \
+  --assign-identity "$MACHINEIDENTITY" \
+  --admin-username azureuser \
+  --subnet "$SUBNETID" \
+  --public-ip-address "" \
+  --size "$MACHINESIZE" \
+  --generate-ssh-keys \
+  --nic-delete-option delete \
+  --os-disk-delete-option delete \
+  --custom-data cloud-init.txt

--- a/ACI/mount_afs.sh
+++ b/ACI/mount_afs.sh
@@ -1,0 +1,107 @@
+#! /bin/sh
+
+#  mount an Azure File Share at a given location.
+#  Requires az cli to be installed and logged in.
+
+usage() {
+    echo "Usage: mount_afs.sh [-h] [-v] -r <resource group> -a <storage account name> -f <file share name> -m <mount point>"
+    echo "  -h: help (this message)"
+    echo "  -v: verbose"
+    echo "  -r: resource group (Required)"
+    echo "  -a: storage account name (Required)"
+    echo "  -f: file share name (Required)"
+    echo "  -m: mount point (Required)"
+    echo "  -?: help"
+    exit 1
+}
+
+while getopts "h?vr:a:f:m:" opt; do
+    case "$opt" in
+    h|\?)
+        usage
+        ;;
+    v)  VERBOSE=1
+        ;;
+    r)  RESOURCEGROUP=$OPTARG
+        ;;
+    a)  STORAGEACCOUNTNAME=$OPTARG
+        ;;
+    f)  FILESHARENAME=$OPTARG
+        ;;
+    m)  MOUNTPOINT=$OPTARG
+        ;;
+    *)
+        usage
+        ;;
+    esac
+done
+
+missing_opts=0
+if [ -z "$RESOURCEGROUP" ]; then
+    echo "ERROR: Resource group is required"
+    missing_opts=1
+fi
+
+if [ -z "$STORAGEACCOUNTNAME" ]; then
+    echo "ERROR: Storage account name is required"
+    missing_opts=1
+fi
+
+if [ -z "$FILESHARENAME" ]; then
+    echo "ERROR: File share name is required"
+    missing_opts=1
+fi
+
+if [ -z "$MOUNTPOINT" ]; then
+    echo "ERROR: Mount point is required"
+    missing_opts=1
+fi
+
+if [ $missing_opts -eq 1 ]; then
+    usage
+fi
+
+if [ -n "$VERBOSE" ]; then
+    echo "RESOURCEGROUP: $RESOURCEGROUP"
+    echo "STORAGEACCOUNTNAME: $STORAGEACCOUNTNAME"
+    echo "FILESHARENAME: $FILESHARENAME"
+    echo "MOUNTPOINT: $MOUNTPOINT"
+fi
+
+# This command assumes you have logged in with az login
+
+if [ -n "$VERBOSE" ]; then
+    echo "Getting https endpoint for storage account $STORAGEACCOUNTNAME"
+fi
+
+httpEndpoint=$(az storage account show \
+  --resource-group "$RESOURCEGROUP" \
+  --name "$STORAGEACCOUNTNAME" \
+  --query "primaryEndpoints.file" --output tsv | tr -d '"')
+smbPath=$(echo "$httpEndpoint" | cut -c7-${#httpEndpoint})$FILESHARENAME
+fileHost=$(echo "$httpEndpoint" | cut -c7-${#httpEndpoint}| tr -d "/")
+nc -zvw3 "$fileHost" 445
+
+if [ -n "$VERBOSE" ]; then
+    echo "httpEndpoint: $httpEndpoint"
+    echo "smbPath: $smbPath"
+    echo "fileHost: $fileHost"
+fi
+
+if [ -n "$VERBOSE" ]; then
+    echo "Getting storage account key"
+fi
+storageAccountKey=$(az storage account keys list \
+  --resource-group "$RESOURCEGROUP" \
+  --account-name "$STORAGEACCOUNTNAME" \
+  --query "[0].value" --output tsv | tr -d '"')
+
+if [ -n "$VERBOSE" ]; then
+    echo "Creating mount path: $MOUNTPOINT"
+fi
+sudo mkdir -p "$MOUNTPOINT"
+
+if [ -n "$VERBOSE" ]; then
+    echo "Mounting $smbPath to $MOUNTPOINT"
+fi
+sudo mount -t cifs "$smbPath" "$MOUNTPOINT" -o username="$STORAGEACCOUNTNAME",password="$storageAccountKey",serverino,nosharesock,actimeo=30,file_mode=0777,nobrl,dir_mode=0777,vers=3.1.1

--- a/ACI/run_dataprep_docker.sh
+++ b/ACI/run_dataprep_docker.sh
@@ -13,7 +13,6 @@ DOCKERIMAGE="transitionmonitordockerregistry.azurecr.io/workflow.data.preparatio
 docker pull $DOCKERIMAGE
 
 docker run \
-  -i -t --rm \
   --env DEPLOY_START_TIME=$(date -u +%Y%m%dT%H%M%SZ) \
   --env LOG_LEVEL=TRACE \
   --env R_CONFIG_ACTIVE=2022Q4_CICD \

--- a/ACI/run_dataprep_docker.sh
+++ b/ACI/run_dataprep_docker.sh
@@ -1,0 +1,24 @@
+#! /bin/sh
+
+az login --identity
+
+mount_afs -v -r pacta-data -a pactarawdata -f factset-extracted -m /mnt/factset-extracted
+mount_afs -v -r pacta-data -a pactarawdata -f rawdata -m /mnt/rawdata
+mount_afs -v -r pacta-data -a pactadata -f data-prep-inputs -m /mnt/dataprep_inputs
+mount_afs -v -r pacta-data -a pactadata -f data-prep-outputs -m /mnt/outputs
+
+az acr login --name transitionmonitordockerregistry
+
+DOCKERIMAGE="transitionmonitordockerregistry.azurecr.io/workflow.data.preparation_aci"
+docker pull $DOCKERIMAGE
+
+docker run \
+  -i -t --rm \
+  --env DEPLOY_START_TIME=$(date -u +%Y%m%dT%H%M%SZ) \
+  --env LOG_LEVEL=TRACE \
+  --env R_CONFIG_ACTIVE=2022Q4_CICD \
+  --mount type=bind,source=/mnt/dataprep_inputs,target=/mnt/dataprep_inputs \
+  --mount type=bind,source=/mnt/factset-extracted,target=/mnt/factset-extracted,readonly \
+  --mount type=bind,source=/mnt/outputs,target=/mnt/outputs \
+  --mount type=bind,source=/mnt/rawdata,target=/mnt/rawdata,readonly \
+  $DOCKERIMAGE


### PR DESCRIPTION
This is a workaround fix, to deal with the fact that ACI only allows 16Gb of RAM on container groups with no GPUs (and we're waiting on Microsoft to approve our quota increase)

This PR adds infrastructure to spin up a VM and use it similar to how we would use ACI.