### PR TITLE
export SQLite files by default

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -8,7 +8,7 @@ default:
   host: "data-eval-db.postgres.database.azure.com"
   update_factset: TRUE
   update_currencies: TRUE
-  export_sqlite_files: FALSE
+  export_sqlite_files: TRUE
   imf_quarter_timestamp: "2021-Q4"
   factset_data_timestamp: "2021-12-31"
   pacta_financial_timestamp: "2021Q4"


### PR DESCRIPTION
I believe that we agreed to turn this on by default in a Tech Review call some weeks ago?