### PR TITLE
add a license

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,3 +46,4 @@ Remotes:
     RMI-PACTA/pacta.scenario.preparation
 Depends: 
     R (>= 3.5.0)
+License: MIT + file LICENSE

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+YEAR: 2024
+COPYRIGHT HOLDER: workflow.data.preparation authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2024 workflow.data.preparation authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
following the logic of [RMI-PACTA/workflow.transition.monitor/pull/232](https://github.com/RMI-PACTA/workflow.transition.monitor/pull/232), this PR does all the appropriate things related to adding a license to the repo, including:
- adding a LICENSE file
- adding a LICENSE.md file
- properly specifying the license in the DESCRIPTION file