### PR TITLE
add a `desktop` config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -92,3 +92,9 @@ default:
   scenario_sources_list: ["GECO2022", "IPR2021", "ISF2021", "WEO2022"]
   scenario_raw_data_to_include: ["geco_2022", "ipr_2021", "isf_2021", "weo_2022"]
   global_aggregate_scenario_sources_list: ["WEO2022"]
+
+desktop:
+  inherits: 2022Q4
+  data_prep_outputs_path: "./outputs"
+  asset_impact_data_path: "./ai_inputs"
+  factset_data_path: "./factset_inputs"


### PR DESCRIPTION
This adds a `desktop` config that can be targeted when running. I'm trying to write the README section for running inn RStudio, and it's actually extremely complicated because this repo has deviated so far from that use case already, so having a separate config (I hope) will facilitate me writing a sane process for running locally.