### PR TITLE
add build preferences to .Rproj file (because it insists)

### DIFF
--- a/workflow.data.preparation.Rproj
+++ b/workflow.data.preparation.Rproj
@@ -16,6 +16,10 @@ AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes
 LineEndingConversion: Posix
 
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+
 UseNativePipeOperator: No
 
 SpellingDictionary: en_US


### PR DESCRIPTION
Because a DESCRIPTION file has been added to this repo, RStudio seems to insist on adding these build preferences to the .Rproj file. As far as I know, they are meaningless and won't cause any problems in this context, so I'm allowing them rather than constantly fighting them to keep my git history clean.