### PR TITLE
add dbplyr dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Encoding: UTF-8
 Imports: 
     config,
     DBI,
+    dbplyr,
     dplyr,
     logger,
     pacta.data.preparation, 


### PR DESCRIPTION
closes #105

To be honest, I don't fully understand why {dbplyr} is needed, but it appears that something in this code requires it...

https://github.com/RMI-PACTA/workflow.data.preparation/blob/c08b8fb5a139716997ae2c0e83a01757d51a9a2d/run_pacta_data_preparation.R#L687-L707

I have verified that adding it allows the Docker run with SQLite export to complete successfully (without the error).