### PR TITLE
installing pre-built binary versions of {pak} in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 FROM --platform=linux/amd64 rocker/tidyverse
 
-RUN Rscript -e 'install.packages("pak")'
+RUN Rscript -e '\
+  install.packages("pak", repos = sprintf( \
+    "https://r-lib.github.io/p/pak/stable/%s/%s/%s", \
+    .Platform$pkgType, \
+    R.Version()$os, \
+    R.Version()$arch \
+  )) \
+  '
 
 COPY . /workflow.data.preparation
 


### PR DESCRIPTION
closes #103 

based on official suggestion by {pak} at https://pak.r-lib.org/reference/install.html#pre-built-binaries