### PR TITLE
use new `pacta.data.preparation::determine_relevant_years()` function

### DIFF
--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -91,11 +91,11 @@ currencies_data_path <- file.path(asset_impact_data_path, "currencies.rds")
 
 # computed options -------------------------------------------------------------
 
-relevant_years <- sort(
-  unique(
-    market_share_target_reference_year:(market_share_target_reference_year + time_horizon)
+relevant_years <- 
+  pacta.data.preparation::determine_relevant_years(
+    market_share_target_reference_year,
+    time_horizon
   )
-)
 logger::log_info(
   "Full time horizon set to: {paste0(relevant_years, collapse = ', ')}."
 )


### PR DESCRIPTION
depends on https://github.com/RMI-PACTA/pacta.data.preparation/pull/333
closes #120 
works toward #94 

- replaces explicit code in [run_pacta_data_preparation.R](https://github.com/RMI-PACTA/workflow.data.preparation/edit/main/run_pacta_data_preparation.R) with the function `pacta.data.preparation::determine_relevant_years()` which wraps all the necessary methodological logic and does robust input checking