### PR TITLE
don't bind mount the repo directory that gets copied in

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,3 @@ services:
       - type: bind
         source: ${HOST_OUTPUTS_PATH}
         target: /outputs
-      - type: bind
-        source: .
-        target: /workflow.data.preparation


### PR DESCRIPTION
depends on #99 

not sure why this was being done since the repo gets permanently copied into the Docker image. @jdhoffa?