### PR TITLE
skip reading `.env` when running in desktop mode

### DIFF
--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -19,7 +19,9 @@ suppressPackageStartupMessages({
 
 # config -----------------------------------------------------------------------
 
-readRenviron(".env")
+if (Sys.getenv("R_CONFIG_ACTIVE") != "desktop") {
+  readRenviron(".env")
+}
 
 config <-
   config::get(


### PR DESCRIPTION
closes #113 
to prevent `.env` from overriding/conflicting with the desired "desktop" config