### PR TITLE
avoid unnecessary intermediate scenario files

### DIFF
--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -119,7 +119,9 @@ if (!update_currencies) {
 }
 
 
-# web scraping (pre-flight) ----------------------------------------------------
+# pre-flight -------------------------------------------------------------------
+
+logger::log_info("Fetching pre-flight data.")
 
 if (update_currencies) {
   logger::log_info("Fetching currency data.")
@@ -131,6 +133,8 @@ if (update_currencies) {
 
 logger::log_info("Scraping index regions.")
 index_regions <- pacta.data.scraping::get_index_regions()
+
+logger::log_info("Fetching pre-flight data done.")
 
 
 # intermediary files -----------------------------------------------------------

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -137,7 +137,7 @@ index_regions <- pacta.data.scraping::get_index_regions()
 logger::log_info("Fetching pre-flight data done.")
 
 
-# intermediary files -----------------------------------------------------------
+# intermediary objects ---------------------------------------------------------
 
 factset_issue_code_bridge <-
   pacta.data.preparation::factset_issue_code_bridge %>%


### PR DESCRIPTION
I believe we originally created these scenario CSVs to faithfully replicate the setup for the former data.prep process, but as far as I know these CSVs are not useful for anything once the current data.prep is completely. In this PR, I move that process further down and rather than export those intermediate files just process the in memory data objects.

@jdhoffa hope you can review this thoroughly and agree