### PR TITLE
add config name and config to manifest

### DIFF
--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -21,10 +21,11 @@ suppressPackageStartupMessages({
 
 readRenviron(".env")
 
+config_name <- Sys.getenv("R_CONFIG_ACTIVE")
 config <-
   config::get(
     file = "config.yml",
-    config = Sys.getenv("R_CONFIG_ACTIVE"),
+    config = config_name,
     use_parent = FALSE
   )
 
@@ -769,6 +770,8 @@ package_news <-
 
 parameters <-
   list(
+    config_name = config_name,
+    config = unclass(config),
     input_filepaths = list(
       masterdata_ownership_path = masterdata_ownership_path,
       masterdata_debt_path = masterdata_debt_path,


### PR DESCRIPTION
As a safety precaution, I think it makes sense to add the specified config name and the config as-is to the manifest file.