### PR TITLE
add `.dockerignore` file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,10 @@
-**/.git
-**/.github
-**/.gitignore
-**/Dockerfile
-**/*.Rproj
-docker-compose.yml
+# ignore everything
+*
+# include certain files
+!config.yml
+!DESCRIPTION
+!Dockerfile
+!LICENSE
+!LICENSE.md
+!README.md
+!run_pacta_data_preparation.R

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/.git
+**/.github
+**/.gitignore
+**/Dockerfile
+**/*.Rproj
+docker-compose.yml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 # ignore everything
 *
 # include certain files
+!.env
 !config.yml
 !DESCRIPTION
 !Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@
 !.env
 !config.yml
 !DESCRIPTION
-!Dockerfile
 !LICENSE
 !LICENSE.md
 !README.md


### PR DESCRIPTION
closes #128 

based on https://github.com/RMI-PACTA/workflow.pacta/blob/main/.dockerignore with the following differences
- allowing markdown files because I think it is reasonably relevant to have the license and README markdown files baked into the image along with the associated code
- excluding the `docker-compose.yml` because that's not relevant inside the image (and I wonder if in some cases it could be a security concern, e.g. if one did not want local path specifications to be revealed inside the image)