### PR TITLE
use new `factset_issue_code_bridge` from `workflow.factset`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,4 @@ The required files are:
 - factset_fund_data.rds
 - factset_isin_to_fund_table.rds
 - factset_iss_emissions.rds
+- factset_issue_code_bridge.rds

--- a/config.yml
+++ b/config.yml
@@ -108,14 +108,12 @@ default:
   imf_quarter_timestamp: "2022-Q4"
   pacta_financial_timestamp: "2022Q4"
   market_share_target_reference_year: 2022
-  scenario_sources_list: ["IPR2021"]
-  scenario_raw_data_to_include: ["ipr_2021"]
+  scenario_sources_list: ["GECO2022", "IPR2021", "ISF2021", "WEO2022"]
+  scenario_raw_data_to_include: ["geco_2022", "ipr_2021", "isf_2021", "weo_2022"]
   global_aggregate_scenario_sources_list: ["WEO2022"]
 
 desktop:
   inherits: 2022Q4
-  data_prep_outputs_path: "/Users/cjrmi/Desktop/dataprep/outputs"
-  asset_impact_data_path: "/Users/cjrmi/Desktop/dataprep/inputs"
-  factset_data_path: "/Users/cjrmi/Desktop/dataprep/inputs"
-  scenario_sources_list: ["IPR2021"]
-  scenario_raw_data_to_include: ["ipr_2021"]
+  data_prep_outputs_path: "./outputs"
+  asset_impact_data_path: "./ai_inputs"
+  factset_data_path: "./factset_inputs"

--- a/config.yml
+++ b/config.yml
@@ -11,6 +11,7 @@ default:
   factset_fund_data_filename: ""
   factset_isin_to_fund_table_filename: ""
   factset_iss_emissions_data_filename: ""
+  factset_issue_code_bridge_filename: ""
   update_currencies: TRUE
   export_sqlite_files: TRUE
   imf_quarter_timestamp: "2021-Q4"
@@ -39,6 +40,7 @@ default:
   factset_fund_data_filename: ""
   factset_isin_to_fund_table_filename: ""
   factset_iss_emissions_data_filename: ""
+  factset_issue_code_bridge_filename: ""
   imf_quarter_timestamp: "2021-Q4"
   pacta_financial_timestamp: "2021Q4"
   market_share_target_reference_year: 2021
@@ -77,6 +79,7 @@ default:
   factset_fund_data_filename: ""
   factset_isin_to_fund_table_filename: ""
   factset_iss_emissions_data_filename: ""
+  factset_issue_code_bridge_filename: ""
   imf_quarter_timestamp: "2022-Q2"
   pacta_financial_timestamp: "2022Q2"
   market_share_target_reference_year: 2022
@@ -101,15 +104,18 @@ default:
   factset_fund_data_filename: "timestamp-20221231T000000Z_pulled-20240207T161053Z_factset_fund_data.rds"
   factset_isin_to_fund_table_filename: "timestamp-20221231T000000Z_pulled-20240207T161053Z_factset_isin_to_fund_table.rds"
   factset_iss_emissions_data_filename: "timestamp-20221231T000000Z_pulled-20240207T161053Z_factset_iss_emissions.rds"
+  factset_issue_code_bridge_filename: "test-from-fds-test-20240207-03-postgres_factset_issue_code_bridge.rds"
   imf_quarter_timestamp: "2022-Q4"
   pacta_financial_timestamp: "2022Q4"
   market_share_target_reference_year: 2022
-  scenario_sources_list: ["GECO2022", "IPR2021", "ISF2021", "WEO2022"]
-  scenario_raw_data_to_include: ["geco_2022", "ipr_2021", "isf_2021", "weo_2022"]
+  scenario_sources_list: ["IPR2021"]
+  scenario_raw_data_to_include: ["ipr_2021"]
   global_aggregate_scenario_sources_list: ["WEO2022"]
 
 desktop:
   inherits: 2022Q4
-  data_prep_outputs_path: "./outputs"
-  asset_impact_data_path: "./ai_inputs"
-  factset_data_path: "./factset_inputs"
+  data_prep_outputs_path: "/Users/cjrmi/Desktop/dataprep/outputs"
+  asset_impact_data_path: "/Users/cjrmi/Desktop/dataprep/inputs"
+  factset_data_path: "/Users/cjrmi/Desktop/dataprep/inputs"
+  scenario_sources_list: ["IPR2021"]
+  scenario_raw_data_to_include: ["ipr_2021"]

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -43,6 +43,7 @@ factset_entity_financing_data_filename <- config$factset_entity_financing_data_f
 factset_fund_data_filename <- config$factset_fund_data_filename
 factset_isin_to_fund_table_filename <- config$factset_isin_to_fund_table_filename
 factset_iss_emissions_data_filename <- config$factset_iss_emissions_data_filename
+factset_issue_code_bridge_filename <- config$factset_issue_code_bridge_filename
 update_currencies <- config$update_currencies
 export_sqlite_files <- config$export_sqlite_files
 imf_quarter_timestamp <- config$imf_quarter_timestamp
@@ -83,6 +84,8 @@ factset_isin_to_fund_table_path <-
   file.path(factset_data_path, factset_isin_to_fund_table_filename)
 factset_iss_emissions_data_path <-
   file.path(factset_data_path, factset_iss_emissions_data_filename)
+factset_issue_code_bridge_path <-
+  file.path(factset_data_path, factset_issue_code_bridge_filename)
 
 
 # pre-flight filepaths ---------------------------------------------------------
@@ -110,7 +113,8 @@ factset_timestamp <-
     factset_entity_financing_data_filename,
     factset_fund_data_filename,
     factset_isin_to_fund_table_filename,
-    factset_iss_emissions_data_filename
+    factset_iss_emissions_data_filename,
+    factset_issue_code_bridge_filename
   )))
 
 
@@ -125,6 +129,7 @@ stopifnot(file.exists(factset_entity_financing_data_path))
 stopifnot(file.exists(factset_fund_data_path))
 stopifnot(file.exists(factset_isin_to_fund_table_path))
 stopifnot(file.exists(factset_iss_emissions_data_path))
+stopifnot(file.exists(factset_issue_code_bridge_path))
 stopifnot(file.exists(data_prep_outputs_path))
 
 if (!update_currencies) {
@@ -152,7 +157,7 @@ logger::log_info("Fetching pre-flight data done.")
 # intermediary objects ---------------------------------------------------------
 
 factset_issue_code_bridge <-
-  pacta.data.preparation::factset_issue_code_bridge %>%
+  readRDS(factset_issue_code_bridge_path) %>%
   select(issue_type_code, asset_type) %>%
   mutate(
     asset_type = case_when(

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -779,7 +779,8 @@ parameters <-
       factset_financial_data_path = factset_financial_data_path,
       factset_entity_info_path = factset_entity_info_path,
       factset_fund_data_path = factset_fund_data_path,
-      factset_isin_to_fund_table_path = factset_isin_to_fund_table_path
+      factset_isin_to_fund_table_path = factset_isin_to_fund_table_path,
+      factset_issue_code_bridge_path = factset_issue_code_bridge_path
     ),
     preflight_filepaths = list(
       currencies_data_path = currencies_data_path


### PR DESCRIPTION
depends on https://github.com/RMI-PACTA/workflow.factset/pull/39
should be done before https://github.com/RMI-PACTA/pacta.data.preparation/pull/335

This tells the workflow to use the `factset_issue_code_bridge` from the FactSet inputs rather than using `pacta.data.preparation::factset_issue_code_bridge` which is set to be deprecated/removed (https://github.com/RMI-PACTA/pacta.data.preparation/issues/321)

⚠️ in this PR, I have temporarily set the default 2022Q4 config `factset_issue_code_bridge_filename` to `test-from-fds-test-20240207-03-postgres_factset_issue_code_bridge.rds` (which was the first version of this new file that I have had access to) to facilitate testing/verifying that this PR works (similar to what has been done with the other FactSet filenames), but these default filenames have not been determined/approved and will need to change once they have been identified, a task which is acknowledged and being tracked in [update explicit FactSet filenames once they are known #108](https://github.com/RMI-PACTA/workflow.data.preparation/issues/108).

For testing, this implies that one has put this `test-from-fds-test-20240207-03-postgres_factset_issue_code_bridge.rds` file in the same inputs directory as the other FactSet input files.