### PR TITLE
use new `factset_industry_map_bridge.rds` from `workflow.factset`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     dbplyr,
     dplyr,
     logger,
-    pacta.data.preparation, 
+    pacta.data.preparation (>= 0.1.0.9001), 
     pacta.data.scraping, 
     pacta.scenario.preparation, 
     readr, 

--- a/README.md
+++ b/README.md
@@ -84,3 +84,4 @@ The required files are:
 - factset_isin_to_fund_table.rds
 - factset_iss_emissions.rds
 - factset_issue_code_bridge.rds
+- factset_industry_map_bridge.rds

--- a/config.yml
+++ b/config.yml
@@ -12,6 +12,7 @@ default:
   factset_isin_to_fund_table_filename: ""
   factset_iss_emissions_data_filename: ""
   factset_issue_code_bridge_filename: ""
+  factset_industry_map_bridge_filename: ""
   update_currencies: TRUE
   export_sqlite_files: TRUE
   imf_quarter_timestamp: "2021-Q4"
@@ -41,6 +42,7 @@ default:
   factset_isin_to_fund_table_filename: ""
   factset_iss_emissions_data_filename: ""
   factset_issue_code_bridge_filename: ""
+  factset_industry_map_bridge_filename: ""
   imf_quarter_timestamp: "2021-Q4"
   pacta_financial_timestamp: "2021Q4"
   market_share_target_reference_year: 2021
@@ -80,6 +82,7 @@ default:
   factset_isin_to_fund_table_filename: ""
   factset_iss_emissions_data_filename: ""
   factset_issue_code_bridge_filename: ""
+  factset_industry_map_bridge_filename: ""
   imf_quarter_timestamp: "2022-Q2"
   pacta_financial_timestamp: "2022Q2"
   market_share_target_reference_year: 2022
@@ -105,6 +108,7 @@ default:
   factset_isin_to_fund_table_filename: "timestamp-20221231T000000Z_pulled-20240207T161053Z_factset_isin_to_fund_table.rds"
   factset_iss_emissions_data_filename: "timestamp-20221231T000000Z_pulled-20240207T161053Z_factset_iss_emissions.rds"
   factset_issue_code_bridge_filename: "test-from-fds-test-20240207-03-postgres_factset_issue_code_bridge.rds"
+  factset_industry_map_bridge_filename: "timestamp-20230123T000000Z_pulled-20000101T000001_factset_industry_map_bridge.rds"
   imf_quarter_timestamp: "2022-Q4"
   pacta_financial_timestamp: "2022Q4"
   market_share_target_reference_year: 2022
@@ -114,6 +118,8 @@ default:
 
 desktop:
   inherits: 2022Q4
-  data_prep_outputs_path: "./outputs"
-  asset_impact_data_path: "./ai_inputs"
-  factset_data_path: "./factset_inputs"
+  data_prep_outputs_path: "~/Desktop/dataprep_local/outputs"
+  asset_impact_data_path: "~/Desktop/dataprep_local/inputs"
+  factset_data_path: "~/Desktop/dataprep_local/inputs"
+  scenario_sources_list: ["IPR2021"]
+  scenario_raw_data_to_include: ["ipr_2021"]

--- a/config.yml
+++ b/config.yml
@@ -118,8 +118,6 @@ default:
 
 desktop:
   inherits: 2022Q4
-  data_prep_outputs_path: "~/Desktop/dataprep_local/outputs"
-  asset_impact_data_path: "~/Desktop/dataprep_local/inputs"
-  factset_data_path: "~/Desktop/dataprep_local/inputs"
-  scenario_sources_list: ["IPR2021"]
-  scenario_raw_data_to_include: ["ipr_2021"]
+  data_prep_outputs_path: "./outputs"
+  asset_impact_data_path: "./ai_inputs"
+  factset_data_path: "./factset_inputs"

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -175,8 +175,7 @@ factset_issue_code_bridge <-
   )
 
 factset_industry_map_bridge <-
-  readRDS(factset_industry_map_bridge_path) %>%
-  select(factset_industry_code, pacta_sector)
+  readRDS(factset_industry_map_bridge_path)
 
 logger::log_info("Preparing scenario data.")
 
@@ -257,7 +256,7 @@ factset_entity_id__ar_company_id <-
 readRDS(factset_entity_info_path) %>%
   pacta.data.preparation::prepare_entity_info(
     factset_entity_id__ar_company_id, 
-    readRDS(factset_industry_map_bridge_path)
+    factset_industry_map_bridge
   ) %>%
   saveRDS(file.path(data_prep_outputs_path, "entity_info.rds"))
 

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -255,7 +255,10 @@ factset_entity_id__ar_company_id <-
   ) %>%
   distinct()
 readRDS(factset_entity_info_path) %>%
-  pacta.data.preparation::prepare_entity_info(factset_entity_id__ar_company_id) %>%
+  pacta.data.preparation::prepare_entity_info(
+    factset_entity_id__ar_company_id, 
+    readRDS(factset_industry_map_bridge_path)
+  ) %>%
   saveRDS(file.path(data_prep_outputs_path, "entity_info.rds"))
 
 logger::log_info("Financial data prepared.")

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -44,6 +44,7 @@ factset_fund_data_filename <- config$factset_fund_data_filename
 factset_isin_to_fund_table_filename <- config$factset_isin_to_fund_table_filename
 factset_iss_emissions_data_filename <- config$factset_iss_emissions_data_filename
 factset_issue_code_bridge_filename <- config$factset_issue_code_bridge_filename
+factset_industry_map_bridge_filename <- config$factset_industry_map_bridge_filename
 update_currencies <- config$update_currencies
 export_sqlite_files <- config$export_sqlite_files
 imf_quarter_timestamp <- config$imf_quarter_timestamp
@@ -86,6 +87,8 @@ factset_iss_emissions_data_path <-
   file.path(factset_data_path, factset_iss_emissions_data_filename)
 factset_issue_code_bridge_path <-
   file.path(factset_data_path, factset_issue_code_bridge_filename)
+factset_industry_map_bridge_path <-
+  file.path(factset_data_path, factset_industry_map_bridge_filename)
 
 
 # pre-flight filepaths ---------------------------------------------------------
@@ -114,7 +117,8 @@ factset_timestamp <-
     factset_fund_data_filename,
     factset_isin_to_fund_table_filename,
     factset_iss_emissions_data_filename,
-    factset_issue_code_bridge_filename
+    factset_issue_code_bridge_filename,
+    factset_industry_map_bridge_filename
   )))
 
 
@@ -130,6 +134,7 @@ stopifnot(file.exists(factset_fund_data_path))
 stopifnot(file.exists(factset_isin_to_fund_table_path))
 stopifnot(file.exists(factset_iss_emissions_data_path))
 stopifnot(file.exists(factset_issue_code_bridge_path))
+stopifnot(file.exists(factset_industry_map_bridge_path))
 stopifnot(file.exists(data_prep_outputs_path))
 
 if (!update_currencies) {
@@ -170,7 +175,7 @@ factset_issue_code_bridge <-
   )
 
 factset_industry_map_bridge <-
-  pacta.data.preparation::factset_industry_map_bridge %>%
+  readRDS(factset_industry_map_bridge_path) %>%
   select(factset_industry_code, pacta_sector)
 
 logger::log_info("Preparing scenario data.")
@@ -782,7 +787,8 @@ parameters <-
       factset_fund_data_path = factset_fund_data_path,
       factset_isin_to_fund_table_path = factset_isin_to_fund_table_path,
       factset_iss_emissions_data_path = factset_iss_emissions_data_path,
-      factset_issue_code_bridge_path = factset_issue_code_bridge_path
+      factset_issue_code_bridge_path = factset_issue_code_bridge_path,
+      factset_industry_map_bridge_path = factset_industry_map_bridge_path
     ),
     preflight_filepaths = list(
       currencies_data_path = currencies_data_path


### PR DESCRIPTION
- [x] depends on https://github.com/RMI-PACTA/workflow.factset/pull/46

must be coordinated with https://github.com/RMI-PACTA/pacta.data.preparation/pull/336

uses the same strategy as #130 did to add the new `factset_issue_code_bridge.rds`, however, this one is a bit more complicated because `pacta.data.preparation::prepare_entity_info()` used `pacta.data.preparation::factset_industry_map_bridge` internally. Because of that, I see no way of doing this without relying on https://github.com/RMI-PACTA/pacta.data.preparation/pull/336 which is also reliant on this PR, i.e. both this PR and https://github.com/RMI-PACTA/pacta.data.preparation/pull/336 should be coordinated to be merged at roughly the same time. The reason being that the function signature of `pacta.data.preparation::prepare_entity_info()` changes and it can no longer function properly without passing `factset_issue_code_bridge`, so wherever it is used in [run_pacta_data_preparation.R](https://github.com/RMI-PACTA/workflow.data.preparation/blob/main/run_pacta_data_preparation.R) it will need to include the new `factset_issue_code_bridge` coming from the new `factset_issue_code_bridge.rds`.


Additional confusion is that `factset_industry_map_bridge` was [loaded](https://github.com/RMI-PACTA/workflow.data.preparation/blob/f9368d717466ea3f86d9b13bac5ac02ae9a5d686/run_pacta_data_preparation.R#L172-L174) and then two columns were selected from it, but then it was never used (!?). This must have been a leftover from some previous time before `pacta.data.preparation::prepare_entity_info()` existed. So in this PR I removed the `select()` and used the raw `factset_industry_map_bridge` object as the input for the new argument of `pacta.data.preparation::prepare_entity_info()`.

This tells the workflow to use the new `factset_industry_map_bridge.rds` from the FactSet inputs rather than using `pacta.data.preparation::factset_industry_map_bridge` which is set to be deprecated/removed in https://github.com/RMI-PACTA/pacta.data.preparation/issues/321

⚠️ in this PR, I have temporarily set the default 2022Q4 config `factset_industry_map_bridge_filename` to `timestamp-20230123T000000Z_pulled-20000101T000001_factset_industry_map_bridge.rds` (which was the first version of this new file that I have had access to on Teams) to facilitate testing/verifying that this PR works (similar to what has been done with the other FactSet filenames), but these default filenames have not been determined/approved and will need to change once they have been identified, a task which is acknowledged and being tracked in [update explicit FactSet filenames once they are known #108](https://github.com/RMI-PACTA/workflow.data.preparation/issues/108).

For testing, this implies that one has put this `timestamp-20230123T000000Z_pulled-20000101T000001_factset_industry_map_bridge.rds` file in the same inputs directory as the other FactSet input files.