### PR TITLE
use new `factset_manual_pacta_sector_override.rds` from `workflow.factset`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     dbplyr,
     dplyr,
     logger,
-    pacta.data.preparation (>= 0.1.0.9001), 
+    pacta.data.preparation (>= 0.1.0.9002), 
     pacta.data.scraping, 
     pacta.scenario.preparation, 
     readr, 

--- a/README.md
+++ b/README.md
@@ -85,3 +85,4 @@ The required files are:
 - factset_iss_emissions.rds
 - factset_issue_code_bridge.rds
 - factset_industry_map_bridge.rds
+- factset_manual_pacta_sector_override.rds

--- a/config.yml
+++ b/config.yml
@@ -113,7 +113,7 @@ default:
   factset_iss_emissions_data_filename: "timestamp-20221231T000000Z_pulled-20240207T161053Z_factset_iss_emissions.rds"
   factset_issue_code_bridge_filename: "test-from-fds-test-20240207-03-postgres_factset_issue_code_bridge.rds"
   factset_industry_map_bridge_filename: "timestamp-20230123T000000Z_pulled-20000101T000001_factset_industry_map_bridge.rds"
-  factset_manual_pacta_sector_override_filename: ""
+  factset_manual_pacta_sector_override_filename: "timestamp-20230123T000000Z_pulled-20000101T000002_factset_manual_sector_override.rds"
   imf_quarter_timestamp: "2022-Q4"
   pacta_financial_timestamp: "2022Q4"
   market_share_target_reference_year: 2022

--- a/config.yml
+++ b/config.yml
@@ -13,6 +13,7 @@ default:
   factset_iss_emissions_data_filename: ""
   factset_issue_code_bridge_filename: ""
   factset_industry_map_bridge_filename: ""
+  factset_manual_pacta_sector_override_filename: ""
   update_currencies: TRUE
   export_sqlite_files: TRUE
   imf_quarter_timestamp: "2021-Q4"
@@ -43,6 +44,7 @@ default:
   factset_iss_emissions_data_filename: ""
   factset_issue_code_bridge_filename: ""
   factset_industry_map_bridge_filename: ""
+  factset_manual_pacta_sector_override_filename: ""
   imf_quarter_timestamp: "2021-Q4"
   pacta_financial_timestamp: "2021Q4"
   market_share_target_reference_year: 2021
@@ -83,6 +85,7 @@ default:
   factset_iss_emissions_data_filename: ""
   factset_issue_code_bridge_filename: ""
   factset_industry_map_bridge_filename: ""
+  factset_manual_pacta_sector_override_filename: ""
   imf_quarter_timestamp: "2022-Q2"
   pacta_financial_timestamp: "2022Q2"
   market_share_target_reference_year: 2022
@@ -110,6 +113,7 @@ default:
   factset_iss_emissions_data_filename: "timestamp-20221231T000000Z_pulled-20240207T161053Z_factset_iss_emissions.rds"
   factset_issue_code_bridge_filename: "test-from-fds-test-20240207-03-postgres_factset_issue_code_bridge.rds"
   factset_industry_map_bridge_filename: "timestamp-20230123T000000Z_pulled-20000101T000001_factset_industry_map_bridge.rds"
+  factset_manual_pacta_sector_override_filename: ""
   imf_quarter_timestamp: "2022-Q4"
   pacta_financial_timestamp: "2022Q4"
   market_share_target_reference_year: 2022

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -45,6 +45,7 @@ factset_isin_to_fund_table_filename <- config$factset_isin_to_fund_table_filenam
 factset_iss_emissions_data_filename <- config$factset_iss_emissions_data_filename
 factset_issue_code_bridge_filename <- config$factset_issue_code_bridge_filename
 factset_industry_map_bridge_filename <- config$factset_industry_map_bridge_filename
+factset_manual_pacta_sector_override_filename <- config$factset_manual_pacta_sector_override_filename
 update_currencies <- config$update_currencies
 export_sqlite_files <- config$export_sqlite_files
 imf_quarter_timestamp <- config$imf_quarter_timestamp
@@ -89,6 +90,8 @@ factset_issue_code_bridge_path <-
   file.path(factset_data_path, factset_issue_code_bridge_filename)
 factset_industry_map_bridge_path <-
   file.path(factset_data_path, factset_industry_map_bridge_filename)
+factset_manual_pacta_sector_override_path <-
+  file.path(factset_data_path, factset_manual_pacta_sector_override_filename)
 
 
 # pre-flight filepaths ---------------------------------------------------------
@@ -118,7 +121,8 @@ factset_timestamp <-
     factset_isin_to_fund_table_filename,
     factset_iss_emissions_data_filename,
     factset_issue_code_bridge_filename,
-    factset_industry_map_bridge_filename
+    factset_industry_map_bridge_filename,
+    factset_manual_pacta_sector_override_filename
   )))
 
 
@@ -135,6 +139,7 @@ stopifnot(file.exists(factset_isin_to_fund_table_path))
 stopifnot(file.exists(factset_iss_emissions_data_path))
 stopifnot(file.exists(factset_issue_code_bridge_path))
 stopifnot(file.exists(factset_industry_map_bridge_path))
+stopifnot(file.exists(factset_manual_pacta_sector_override_path))
 stopifnot(file.exists(data_prep_outputs_path))
 
 if (!update_currencies) {
@@ -176,6 +181,9 @@ factset_issue_code_bridge <-
 
 factset_industry_map_bridge <-
   readRDS(factset_industry_map_bridge_path)
+
+factset_manual_pacta_sector_override <-
+  readRDS(factset_manual_pacta_sector_override_path)
 
 logger::log_info("Preparing scenario data.")
 
@@ -255,8 +263,9 @@ factset_entity_id__ar_company_id <-
   distinct()
 readRDS(factset_entity_info_path) %>%
   pacta.data.preparation::prepare_entity_info(
-    factset_entity_id__ar_company_id, 
-    factset_industry_map_bridge
+    factset_entity_id__ar_company_id,
+    factset_industry_map_bridge,
+    factset_manual_pacta_sector_override
   ) %>%
   saveRDS(file.path(data_prep_outputs_path, "entity_info.rds"))
 
@@ -790,7 +799,8 @@ parameters <-
       factset_isin_to_fund_table_path = factset_isin_to_fund_table_path,
       factset_iss_emissions_data_path = factset_iss_emissions_data_path,
       factset_issue_code_bridge_path = factset_issue_code_bridge_path,
-      factset_industry_map_bridge_path = factset_industry_map_bridge_path
+      factset_industry_map_bridge_path = factset_industry_map_bridge_path,
+      factset_manual_pacta_sector_override_path = factset_manual_pacta_sector_override_path
     ),
     preflight_filepaths = list(
       currencies_data_path = currencies_data_path


### PR DESCRIPTION
- [x] depends on https://github.com/RMI-PACTA/workflow.factset/pull/47

must be coordinated with https://github.com/RMI-PACTA/pacta.data.preparation/pull/338

uses the same strategy as #133 did to add the new `factset_industry_map_bridge.rds`, including the complicated process of modifying the function signature of `prepare_entity_info()` and all that flows from that, which necessitates coordination with the connected PR in pacta.data.preparation and a dev version bump

note: as was done with the `factset_industry_map_bridge`, I load the `factset_manual_pacta_sector_override.rds` in the "intermediary files" section of the script

This tells the workflow to use the new `factset_manual_pacta_sector_override.rds` from the FactSet inputs rather than using `pacta.data.preparation::factset_manual_pacta_sector_override` which is set to be deprecated/removed in https://github.com/RMI-PACTA/pacta.data.preparation/issues/321

⚠️ in this PR, I have temporarily set the default 2022Q4 config `factset_manual_pacta_sector_override_filename` to `timestamp-20230123T000000Z_pulled-20000101T000002_factset_manual_sector_override.rds` (which was the first version of this new file that I have had access) to facilitate testing/verifying that this PR works (similar to what has been done with the other FactSet filenames), but these default filenames have not been determined/approved and will need to change once they have been identified, a task which is acknowledged and being tracked in [update explicit FactSet filenames once they are known #108](https://github.com/RMI-PACTA/workflow.data.preparation/issues/108).

For testing, this implies that one has put this `timestamp-20230123T000000Z_pulled-20000101T000002_factset_manual_sector_override.rds` file in the same inputs directory as the other FactSet input files.