### PR TITLE
force garbage collection after large objects are removed

### DIFF
--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -240,10 +240,12 @@ logger::log_info("Formatting and saving file: \"financial_data.rds\".")
 readRDS(factset_financial_data_path) %>%
   pacta.data.preparation::prepare_financial_data(factset_issue_code_bridge) %>%
   saveRDS(file.path(data_prep_outputs_path, "financial_data.rds"))
+invisible(gc())
 
 logger::log_info("Formatting and saving file: \"entity_financing.rds\".")
 readRDS(factset_entity_financing_data_path) %>%
   saveRDS(file.path(data_prep_outputs_path, "entity_financing.rds"))
+invisible(gc())
 
 logger::log_info("Formatting and saving file: \"entity_info.rds\".")
 factset_entity_id__ar_company_id <-
@@ -255,10 +257,11 @@ factset_entity_id__ar_company_id <-
   distinct()
 readRDS(factset_entity_info_path) %>%
   pacta.data.preparation::prepare_entity_info(
-    factset_entity_id__ar_company_id, 
+    factset_entity_id__ar_company_id,
     factset_industry_map_bridge
   ) %>%
   saveRDS(file.path(data_prep_outputs_path, "entity_info.rds"))
+invisible(gc())
 
 logger::log_info("Financial data prepared.")
 
@@ -282,6 +285,7 @@ ar_company_id__credit_parent_ar_company_id <-
   distinct()
 
 rm(entity_info)
+invisible(gc())
 
 
 logger::log_info(
@@ -294,6 +298,7 @@ readr::read_csv(masterdata_ownership_path, na = "", show_col_types = FALSE) %>%
     zero_emission_factor_techs
   ) %>%
   saveRDS(file.path(data_prep_outputs_path, "masterdata_ownership_datastore.rds"))
+invisible(gc())
 
 
 logger::log_info(
@@ -330,12 +335,15 @@ masterdata_debt %>%
     .groups = "drop"
   ) %>%
   saveRDS(file.path(data_prep_outputs_path, "masterdata_debt_datastore.rds"))
+invisible(gc())
 
 rm(masterdata_debt)
 rm(company_id__creditor_company_id)
+invisible(gc())
 
 rm(ar_company_id__country_of_domicile)
 rm(ar_company_id__credit_parent_ar_company_id)
+invisible(gc())
 
 logger::log_info("ABCD prepared.")
 
@@ -355,6 +363,13 @@ factset_entity_id__ar_company_id <-
 factset_entity_id__security_mapped_sector <-
   entity_info %>%
   select(factset_entity_id, security_mapped_sector)
+
+factset_entity_id__credit_parent_id <-
+  entity_info %>%
+  select("factset_entity_id", "credit_parent_id")
+
+rm(entity_info)
+invisible(gc())
 
 
 logger::log_info("Formatting and saving file: \"abcd_flags_equity.rds\".")
@@ -380,6 +395,7 @@ financial_data %>%
     sectors_with_assets
   ) %>%
   saveRDS(file.path(data_prep_outputs_path, "abcd_flags_equity.rds"))
+invisible(gc())
 
 
 logger::log_info("Formatting and saving file: \"abcd_flags_bonds.rds\".")
@@ -398,10 +414,7 @@ financial_data %>%
   left_join(ar_company_id__sectors_with_assets__debt, by = "ar_company_id") %>%
   mutate(has_asset_level_data = if_else(is.na(sectors_with_assets) | sectors_with_assets == "", FALSE, TRUE)) %>%
   mutate(has_ald_in_fin_sector = if_else(stringr::str_detect(sectors_with_assets, security_mapped_sector), TRUE, FALSE)) %>%
-  left_join(
-    select(entity_info, "factset_entity_id", "credit_parent_id"),
-    by = "factset_entity_id"
-  ) %>%
+  left_join(factset_entity_id__credit_parent_id, by = "factset_entity_id") %>%
   mutate(
     # If FactSet has no credit_parent, we define the company as it's own parent
     credit_parent_id = if_else(is.na(credit_parent_id), factset_entity_id, credit_parent_id)
@@ -414,12 +427,15 @@ financial_data %>%
   ) %>%
   ungroup() %>%
   saveRDS(file.path(data_prep_outputs_path, "abcd_flags_bonds.rds"))
+invisible(gc())
 
 
 rm(financial_data)
-rm(entity_info)
 rm(factset_entity_id__ar_company_id)
 rm(factset_entity_id__security_mapped_sector)
+rm(factset_entity_id__credit_parent_id)
+invisible(gc())
+
 logger::log_info("ABCD flags prepared.")
 
 
@@ -490,6 +506,7 @@ isin_to_fund_table %>%
 
 rm(fund_data)
 rm(isin_to_fund_table)
+invisible(gc())
 
 logger::log_info("Fund data prepared.")
 
@@ -577,6 +594,7 @@ iss_entity_emission_intensities %>%
 rm(iss_company_emissions)
 rm(iss_entity_emission_intensities)
 rm(factset_entity_info)
+invisible(gc())
 
 logger::log_info("Emissions data prepared.")
 
@@ -608,7 +626,11 @@ for (scenario_source in unique(scenarios_long$scenario_source)) {
     index_regions = index_regions
   ) %>%
     saveRDS(file.path(data_prep_outputs_path, filename))
+  invisible(gc())
 }
+
+rm(masterdata_ownership_datastore)
+invisible(gc())
 
 logger::log_info("Formatting and saving file: \"equity_abcd_scenario.rds\".")
 list.files(
@@ -644,7 +666,11 @@ for (scenario_source in unique(scenarios_long$scenario_source)) {
     index_regions = index_regions
   ) %>%
     saveRDS(file.path(data_prep_outputs_path, filename))
+  invisible(gc())
 }
+
+rm(masterdata_debt_datastore)
+invisible(gc())
 
 logger::log_info("Formatting and saving file: \"bonds_abcd_scenario.rds\".")
 list.files(
@@ -685,6 +711,7 @@ if (export_sqlite_files) {
 
   DBI::dbDisconnect(con)
   rm(entity_info)
+  invisible(gc())
 
   # equity_abcd_scenario
   logger::log_info(
@@ -717,6 +744,7 @@ if (export_sqlite_files) {
 
   DBI::dbDisconnect(con)
   rm(equity_abcd_scenario)
+  invisible(gc())
 
   # bonds_abcd_scenario
   logger::log_info(
@@ -749,6 +777,7 @@ if (export_sqlite_files) {
 
   DBI::dbDisconnect(con)
   rm(bonds_abcd_scenario)
+  invisible(gc())
 }
 
 


### PR DESCRIPTION
By forcing garbage collection after large objects are removed, significantly better memory management is achieved.

I don't relish doing this, but it works...

Before
<img width="490" alt="Screenshot 2024-02-16 at 09 14 04" src="https://github.com/RMI-PACTA/workflow.data.preparation/assets/1708872/e1b0360e-6fb5-4c97-86b5-03ca3e6d04a2">

After
<img width="496" alt="Screenshot 2024-02-16 at 10 39 30" src="https://github.com/RMI-PACTA/workflow.data.preparation/assets/1708872/107cc792-31ad-44b9-92b9-ce32bbd64acd">
