### PR TITLE
feat(app): #148 Export data from scraped files

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2,6 +2,7 @@ default:
   data_prep_outputs_path: "/outputs"
   asset_impact_data_path: "/inputs"
   factset_data_path: "/inputs"
+  preflight_data_path: ""
   masterdata_ownership_filename: ""
   masterdata_debt_filename: ""
   ar_company_id__factset_entity_id_filename: ""
@@ -127,3 +128,4 @@ desktop:
   data_prep_outputs_path: "./outputs"
   asset_impact_data_path: "./ai_inputs"
   factset_data_path: "./factset_inputs"
+  preflight_data_path: ""

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -96,8 +96,15 @@ factset_manual_pacta_sector_override_path <-
 
 # pre-flight filepaths ---------------------------------------------------------
 
+preflight_data_path <- config$preflight_data_path
+if (preflight_data_path == "") {
+  preflight_data_path <- data_prep_outputs_path
+}
+
+currencies_preflight_data_path <- file.path(preflight_data_path, "currencies.rds")
 currencies_data_path <- file.path(data_prep_outputs_path, "currencies.rds")
 
+index_regions_preflight_data_path <- file.path(preflight_data_path, "index_regions.rds")
 
 # computed options -------------------------------------------------------------
 
@@ -156,10 +163,16 @@ if (update_currencies) {
   currencies <- pacta.data.scraping::get_currency_exchange_rates(
     quarter = imf_quarter_timestamp
   )
+  saveRDS(currencies, currencies_preflight_data_path)
+} else {
+  logger::log_info("Using pre-existing currency data.")
+  # This requires the preflight path to be defined in the config
+  currencies <- readRDS(currencies_preflight_data_path)
 }
 
 logger::log_info("Scraping index regions.")
 index_regions <- pacta.data.scraping::get_index_regions()
+saveRDS(index_regions, index_regions_preflight_data_path)
 
 logger::log_info("Fetching pre-flight data done.")
 


### PR DESCRIPTION
Changes in this PR export data from scraped sources to file, so that all sources for a dataset are captured, and the dataset can be recreated later.

By default, exports to data prep outputs path, but can be specified with `preflight_data_path`. Writing to the outputs path by default, since this matches current behavior, and we do not have a unified inputs path that we are currently using.

Closes: #148