### PR TITLE
feat(app): #151 Put outputs into unique timestamped directory

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -15,7 +15,6 @@ default:
   factset_industry_map_bridge_filename: ""
   factset_manual_pacta_sector_override_filename: ""
   update_currencies: TRUE
-  timestamp_export_directory: TRUE
   export_sqlite_files: TRUE
   imf_quarter_timestamp: "2021-Q4"
   pacta_financial_timestamp: "2021Q4"

--- a/config.yml
+++ b/config.yml
@@ -15,6 +15,7 @@ default:
   factset_industry_map_bridge_filename: ""
   factset_manual_pacta_sector_override_filename: ""
   update_currencies: TRUE
+  timestamp_export_directory: TRUE
   export_sqlite_files: TRUE
   imf_quarter_timestamp: "2021-Q4"
   pacta_financial_timestamp: "2021Q4"
@@ -127,3 +128,4 @@ desktop:
   data_prep_outputs_path: "./outputs"
   asset_impact_data_path: "./ai_inputs"
   factset_data_path: "./factset_inputs"
+  timestamp_export_directory: FALSE

--- a/config.yml
+++ b/config.yml
@@ -127,4 +127,3 @@ desktop:
   data_prep_outputs_path: "./outputs"
   asset_impact_data_path: "./ai_inputs"
   factset_data_path: "./factset_inputs"
-  timestamp_export_directory: FALSE

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -33,7 +33,6 @@ config <-
 
 asset_impact_data_path <- config$asset_impact_data_path
 factset_data_path <- config$factset_data_path
-data_prep_outputs_path <- config$data_prep_outputs_path
 masterdata_ownership_filename <- config$masterdata_ownership_filename
 masterdata_debt_filename <- config$masterdata_debt_filename
 ar_company_id__factset_entity_id_filename <- config$ar_company_id__factset_entity_id_filename
@@ -64,6 +63,24 @@ scenario_geographies_list <- config$scenario_geographies_list
 global_aggregate_scenario_sources_list <- config$global_aggregate_scenario_sources_list
 global_aggregate_sector_list <- config$global_aggregate_sector_list
 
+system_timestamp <- format(
+      Sys.time(),
+      format = "%Y%m%dT%H%M%SZ",
+      tz = "UTC"
+    )
+
+data_prep_outputs_path <- file.path(
+  config$data_prep_outputs_path,
+  paste(pacta_financial_timestamp, system_timestamp, sep = "_")
+)
+
+if (dir.exists(data_prep_outputs_path)) {
+  logger::log_warn("POTENTIAL DATA LOSS: Output directory already exists, and files may be overwritten ({data_prep_outputs_path}).")
+  warning("Output directory exists. Files may be overwritten.")
+} else {
+  logger::log_trace("Creating output directory: \"{data_prep_outputs_path}\"")
+  dir.create(data_prep_outputs_path, recursive = TRUE)
+}
 
 # input filepaths --------------------------------------------------------------
 

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -900,36 +900,6 @@ for (pkg_name in pacta_packages) {
   )
 }
 
-# Create archive files
-logger::log_info("Exporting input and output archives.")
-
-logger::log_debug("Creating inputs zip file.")
-inputs_zip_file_path <- paste0(data_prep_outputs_path, "_inputs.zip")
-logger::log_trace("Zip file path: \"{inputs_zip_file_path}\".")
-zip(
-  zipfile = inputs_zip_file_path,
-  files = unlist(parameters[["input_filepaths"]]),
-  extras = c(
-    "--junk-paths", # do not preserve paths
-    "--no-dir-entries", # do not include directory entries
-    "--quiet" # do not print progress to stdout
-  )
-)
-logger::log_debug("Inputs archive created.")
-
-logger::log_debug("Creating outputs zip file.")
-outputs_zip_file_path <- paste0(data_prep_outputs_path, ".zip")
-logger::log_trace("Zip file path: \"{outputs_zip_file_path}\".")
-zip(
-  zipfile = outputs_zip_file_path,
-  files = list.files(data_prep_outputs_path, full.names = TRUE, recursive = TRUE),
-  extras = c(
-    "--junk-paths", # do not preserve paths
-    "--no-dir-entries", # do not include directory entries
-    "--quiet" # do not print progress to stdout
-  )
-)
-logger::log_debug("Outputs archive created.")
 
 # ------------------------------------------------------------------------------
 

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -900,6 +900,36 @@ for (pkg_name in pacta_packages) {
   )
 }
 
+# Create archive files
+logger::log_info("Exporting input and output archives.")
+
+logger::log_debug("Creating inputs zip file.")
+inputs_zip_file_path <- paste0(data_prep_outputs_path, "_inputs.zip")
+logger::log_trace("Zip file path: \"{inputs_zip_file_path}\".")
+zip(
+  zipfile = inputs_zip_file_path,
+  files = unlist(parameters[["input_filepaths"]]),
+  extras = c(
+    "--junk-paths", # do not preserve paths
+    "--no-dir-entries", # do not include directory entries
+    "--quiet" # do not print progress to stdout
+  )
+)
+logger::log_debug("Inputs archive created.")
+
+logger::log_debug("Creating outputs zip file.")
+outputs_zip_file_path <- paste0(data_prep_outputs_path, ".zip")
+logger::log_trace("Zip file path: \"{outputs_zip_file_path}\".")
+zip(
+  zipfile = outputs_zip_file_path,
+  files = list.files(data_prep_outputs_path, full.names = TRUE, recursive = TRUE),
+  extras = c(
+    "--junk-paths", # do not preserve paths
+    "--no-dir-entries", # do not include directory entries
+    "--quiet" # do not print progress to stdout
+  )
+)
+logger::log_debug("Outputs archive created.")
 
 # ------------------------------------------------------------------------------
 

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -64,20 +64,16 @@ scenario_geographies_list <- config$scenario_geographies_list
 global_aggregate_scenario_sources_list <- config$global_aggregate_scenario_sources_list
 global_aggregate_sector_list <- config$global_aggregate_sector_list
 
-# determine output path 
-if (config[["timestamp_export_directory"]]) {
-  system_timestamp <- format(
-    Sys.time(),
-    format = "%Y%m%dT%H%M%SZ",
-    tz = "UTC"
-  )
-  data_prep_outputs_path <- file.path(
-    config$data_prep_outputs_path,
-    paste(pacta_financial_timestamp, system_timestamp, sep = "_")
-  )
-} else {
-  data_prep_outputs_path <- config$data_prep_outputs_path
-}
+# create timestamped output directory
+system_timestamp <- format(
+  Sys.time(),
+  format = "%Y%m%dT%H%M%SZ",
+  tz = "UTC"
+)
+data_prep_outputs_path <- file.path(
+  data_prep_outputs_path,
+  paste(pacta_financial_timestamp, system_timestamp, sep = "_")
+)
 
 if (dir.exists(data_prep_outputs_path)) {
   logger::log_warn("POTENTIAL DATA LOSS: Output directory already exists, and files may be overwritten ({data_prep_outputs_path}).")

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -33,6 +33,7 @@ config <-
 
 asset_impact_data_path <- config$asset_impact_data_path
 factset_data_path <- config$factset_data_path
+data_prep_outputs_path <- config$data_prep_outputs_path
 masterdata_ownership_filename <- config$masterdata_ownership_filename
 masterdata_debt_filename <- config$masterdata_debt_filename
 ar_company_id__factset_entity_id_filename <- config$ar_company_id__factset_entity_id_filename

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -63,16 +63,20 @@ scenario_geographies_list <- config$scenario_geographies_list
 global_aggregate_scenario_sources_list <- config$global_aggregate_scenario_sources_list
 global_aggregate_sector_list <- config$global_aggregate_sector_list
 
-system_timestamp <- format(
-      Sys.time(),
-      format = "%Y%m%dT%H%M%SZ",
-      tz = "UTC"
-    )
-
-data_prep_outputs_path <- file.path(
-  config$data_prep_outputs_path,
-  paste(pacta_financial_timestamp, system_timestamp, sep = "_")
-)
+# determine output path 
+if (config[["timestamp_export_directory"]]) {
+  system_timestamp <- format(
+    Sys.time(),
+    format = "%Y%m%dT%H%M%SZ",
+    tz = "UTC"
+  )
+  data_prep_outputs_path <- file.path(
+    config$data_prep_outputs_path,
+    paste(pacta_financial_timestamp, system_timestamp, sep = "_")
+  )
+} else {
+  data_prep_outputs_path <- config$data_prep_outputs_path
+}
 
 if (dir.exists(data_prep_outputs_path)) {
   logger::log_warn("POTENTIAL DATA LOSS: Output directory already exists, and files may be overwritten ({data_prep_outputs_path}).")


### PR DESCRIPTION
create a unique directory for outputs, and warn if it already exists

Directory name includes both pacta timestamp (2022Q4), and creation date (approximately the time the process starts, within a few seconds if run as script).

Example: `/outputs/2022Q4_20240218T165613Z` rather than just `/outputs`

~Additionally, exports 2 `zip` archives: one of all the input files, and another of the contents of the outputs directory~ See #159 

Closes: #151

See Also: #152 