### PR TITLE
refactor(deploy): Harmonize docker mount points

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,5 @@
 default:
-  data_prep_outputs_path: "/outputs"
+  data_prep_outputs_path: "/mnt/outputs"
   asset_impact_data_path: "/inputs"
   factset_data_path: "/inputs"
   masterdata_ownership_filename: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,4 @@ services:
         target: /inputs
       - type: bind
         source: ${HOST_OUTPUTS_PATH}
-        target: /outputs
+        target: /mnt/outputs


### PR DESCRIPTION
Change from /outputs to /mnt/outputs, to match structure defined in #142 and #145

No associated issue.