### PR TITLE
build(docker): #138 Allow .git in build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 *
 # include certain files
 !.env
+!.git
 !config.yml
 !DESCRIPTION
 !LICENSE


### PR DESCRIPTION
We may want to have a more elegant solution in the future (see discussion in #138), but this works for now to include git status in the manifest export.

Closes: #138