### PR TITLE
cleanup config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -33,9 +33,9 @@ default:
 
 desktop:
   inherits: 2022Q4
-  data_prep_outputs_path: "~/Desktop/dataprep_local/outputs"
-  asset_impact_data_path: "~/Desktop/dataprep_local/inputs"
-  factset_data_path: "~/Desktop/dataprep_local/inputs"
+  data_prep_outputs_path: "./outputs"
+  asset_impact_data_path: "./ai_inputs"
+  factset_data_path: "./factset_inputs"
 
 docker:
   data_prep_outputs_path: "/outputs"

--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,7 @@
 default:
-  data_prep_outputs_path: "/outputs"
-  asset_impact_data_path: "/inputs"
-  factset_data_path: "/inputs"
+  data_prep_outputs_path: ""
+  asset_impact_data_path: ""
+  factset_data_path: ""
   masterdata_ownership_filename: ""
   masterdata_debt_filename: ""
   ar_company_id__factset_entity_id_filename: ""
@@ -16,6 +16,47 @@ default:
   factset_manual_pacta_sector_override_filename: ""
   update_currencies: TRUE
   export_sqlite_files: TRUE
+  imf_quarter_timestamp: ""
+  pacta_financial_timestamp: ""
+  market_share_target_reference_year:
+  time_horizon: 5
+  scenario_sources_list: []
+  sector_list: []
+  other_sector_list: []
+  zero_emission_factor_techs: []
+  green_techs: []
+  scenario_raw_data_to_include: []
+  tech_exclude: []
+  scenario_geographies_list: []
+  global_aggregate_scenario_sources_list: []
+  global_aggregate_sector_list: []
+
+desktop:
+  inherits: 2022Q4
+  data_prep_outputs_path: "~/Desktop/dataprep_local/outputs"
+  asset_impact_data_path: "~/Desktop/dataprep_local/inputs"
+  factset_data_path: "~/Desktop/dataprep_local/inputs"
+
+docker:
+  data_prep_outputs_path: "/outputs"
+  asset_impact_data_path: "/inputs"
+  factset_data_path: "/inputs"
+
+
+2021Q4:
+  inherits: docker
+  masterdata_ownership_filename: "2023-06-05_AI_RMI Bespoke_Company Data Products_masterdata_ownership_2021q4.csv"
+  masterdata_debt_filename: "2023-06-05_AI_RMI Bespoke_Company Data Products_masterdata_debt_2021q4.csv"
+  ar_company_id__factset_entity_id_filename: "2022-08-17_rmi_ar_fs_id_bridge_2021q4.csv"
+  factset_financial_data_filename: ""
+  factset_entity_info_filename: ""
+  factset_entity_financing_data_filename: ""
+  factset_fund_data_filename: ""
+  factset_isin_to_fund_table_filename: ""
+  factset_iss_emissions_data_filename: ""
+  factset_issue_code_bridge_filename: ""
+  factset_industry_map_bridge_filename: ""
+  factset_manual_pacta_sector_override_filename: ""
   imf_quarter_timestamp: "2021-Q4"
   pacta_financial_timestamp: "2021Q4"
   market_share_target_reference_year: 2021
@@ -32,48 +73,8 @@ default:
   global_aggregate_sector_list: ["Power"]
 
 
-2021Q4:
-  masterdata_ownership_filename: "2023-06-05_AI_RMI Bespoke_Company Data Products_masterdata_ownership_2021q4.csv"
-  masterdata_debt_filename: "2023-06-05_AI_RMI Bespoke_Company Data Products_masterdata_debt_2021q4.csv"
-  ar_company_id__factset_entity_id_filename: "2022-08-17_rmi_ar_fs_id_bridge_2021q4.csv"
-  factset_financial_data_filename: ""
-  factset_entity_info_filename: ""
-  factset_entity_financing_data_filename: ""
-  factset_fund_data_filename: ""
-  factset_isin_to_fund_table_filename: ""
-  factset_iss_emissions_data_filename: ""
-  factset_issue_code_bridge_filename: ""
-  factset_industry_map_bridge_filename: ""
-  factset_manual_pacta_sector_override_filename: ""
-  imf_quarter_timestamp: "2021-Q4"
-  pacta_financial_timestamp: "2021Q4"
-  market_share_target_reference_year: 2021
-  scenario_sources_list: ["ETP2020", "GECO2021", "IPR2021", "ISF2021", "WEO2021"]
-  sector_list: ["Automotive", "Power", "Fossil Fuels", "Oil&Gas", "Coal"]
-  other_sector_list: ["Steel", "Aviation", "Cement"]
-  zero_emission_factor_techs: ["Electric", "HydroCap", "NuclearCap", "RenewablesCap"]
-  green_techs: ["FuelCell", "Electric", "Hybrid", "RenewablesCap", "HydroCap", "NuclearCap", "FuelCell_HDV", "Electric_HDV", "Hybrid_HDV"]
-  scenario_raw_data_to_include: ["etp_2020", "geco_2021", "ipr_2021", "isf_2021", "weo_2021"]
-  tech_exclude: ["OtherCap", "OtherFF", "Coking Plant", "Sintering Plant", "Direct Or Smelting Reduction Plant", "Pelletizing Plant", "Grinding Plant", "Passenger / Freight"]
-  scenario_geographies_list: ["Global", "NonOECD", "OECD"]
-  global_aggregate_scenario_sources_list: ["ETP2020", "GECO2021", "IPR2021", "ISF2021", "WEO2021"]
-  global_aggregate_sector_list: ["Power"]
-
-2021Q4_dev_vm:
-  inherits: 2021Q4
-
-2021Q4_dev_local:
-  inherits: 2021Q4
-
-2021Q4_prod_vm:
-  inherits: 2021Q4
-
-2021Q4_sqlite:
-  inherits: 2021Q4
-  export_sqlite_files: TRUE
-
-
 2022Q2:
+  inherits: docker
   masterdata_ownership_filename: "2022-08-30_rmi_masterdata_ownership_2022q2.csv"
   masterdata_debt_filename: "2022-10-03_rmi_masterdata_debt_2022q2.csv"
   ar_company_id__factset_entity_id_filename: "2022-08-17_rmi_ar_fs_id_bridge_2021q4.csv"
@@ -89,6 +90,7 @@ default:
   imf_quarter_timestamp: "2022-Q2"
   pacta_financial_timestamp: "2022Q2"
   market_share_target_reference_year: 2022
+  time_horizon: 5
   scenario_sources_list: ["ETP2020", "GECO2021", "IPR2021", "ISF2021", "WEO2021"]
   sector_list: ["Automotive", "Power", "Fossil Fuels", "Oil&Gas", "Coal"]
   other_sector_list: ["Steel", "Aviation", "Cement"]
@@ -102,6 +104,7 @@ default:
 
 
 2022Q4:
+  inherits: docker
   masterdata_ownership_filename: "2023-06-18_AI_RMI Bespoke_Company Data Products_masterdata_ownership_2022Q4.csv"
   masterdata_debt_filename: "2023-06-18_AI_RMI Bespoke_Company Data Products_masterdata_debt_2022Q4.csv"
   ar_company_id__factset_entity_id_filename: "2023-02-15_AI_RMI_Bespoke_Company_Data_Products_Company_ID_List_2022Q4.csv"
@@ -117,13 +120,14 @@ default:
   imf_quarter_timestamp: "2022-Q4"
   pacta_financial_timestamp: "2022Q4"
   market_share_target_reference_year: 2022
+  time_horizon: 5
   scenario_sources_list: ["GECO2022", "ISF2021", "WEO2022"]
+  sector_list: ["Automotive", "Power", "Fossil Fuels", "Oil&Gas", "Coal"]
+  other_sector_list: ["Steel", "Aviation", "Cement"]
+  zero_emission_factor_techs: ["Electric", "HydroCap", "NuclearCap", "RenewablesCap"]
+  green_techs: ["FuelCell", "Electric", "Hybrid", "RenewablesCap", "HydroCap", "NuclearCap", "FuelCell_HDV", "Electric_HDV", "Hybrid_HDV"]
   scenario_raw_data_to_include: ["geco_2022", "isf_2021", "weo_2022"]
+  tech_exclude: ["OtherCap", "OtherFF", "Coking Plant", "Sintering Plant", "Direct Or Smelting Reduction Plant", "Pelletizing Plant", "Grinding Plant", "Passenger / Freight"]
+  scenario_geographies_list: ["Global", "NonOECD", "OECD"]
   global_aggregate_scenario_sources_list: ["WEO2022"]
-
-
-desktop:
-  inherits: 2022Q4
-  data_prep_outputs_path: "./outputs"
-  asset_impact_data_path: "./ai_inputs"
-  factset_data_path: "./factset_inputs"
+  global_aggregate_sector_list: ["Power"]

--- a/config.yml
+++ b/config.yml
@@ -122,7 +122,7 @@ docker:
   market_share_target_reference_year: 2022
   time_horizon: 5
   scenario_sources_list: ["GECO2022", "ISF2021", "WEO2022"]
-  sector_list: ["Automotive", "Power", "Fossil Fuels", "Oil&Gas", "Coal"]
+  sector_list: ["Automotive", "Power", "Oil&Gas", "Coal"]
   other_sector_list: ["Steel", "Aviation", "Cement"]
   zero_emission_factor_techs: ["Electric", "HydroCap", "NuclearCap", "RenewablesCap"]
   green_techs: ["FuelCell", "Electric", "Hybrid", "RenewablesCap", "HydroCap", "NuclearCap", "FuelCell_HDV", "Electric_HDV", "Hybrid_HDV"]


### PR DESCRIPTION
- removes timestamp specific values from "default" config
- moves context specific configs to set directory paths towards the top
- makes timestamp configs inherit directory paths from new "docker" config

note: #145 will "officialize" the 2022Q4 values