### PR TITLE
update paths for local docker context

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -41,8 +41,8 @@ desktop:
 
 docker:
   data_prep_outputs_path: "/mnt/outputs"
-  asset_impact_data_path: "/inputs"
-  factset_data_path: "/inputs"
+  asset_impact_data_path: "/mnt/asset-impact"
+  factset_data_path: "/mnt/factset-extracted"
 
 
 2021Q4:
@@ -106,6 +106,7 @@ docker:
 
 
 2022Q4:
+  inherits: docker
   masterdata_ownership_filename: "2023-06-18_AI_RMI Bespoke_Company Data Products_masterdata_ownership_2022Q4.csv"
   masterdata_debt_filename: "2023-06-18_AI_RMI Bespoke_Company Data Products_masterdata_debt_2022Q4.csv"
   ar_company_id__factset_entity_id_filename: "2023-02-15_AI_RMI_Bespoke_Company_Data_Products_Company_ID_List_2022Q4.csv"


### PR DESCRIPTION
Update local docker config to match changes made to [docker-compose.yml](https://github.com/RMI-PACTA/workflow.data.preparation/blob/main/docker-compose.yml) in #142

Also set `2022Q4` config to inherit the `docker` config again (removed in #145). @AlexAxthelm this should not affect the `2022Q4_azure` because `2022Q4` will inherit the `docker` config, but when `2022Q4_azure` inherits `2022Q4` it will overwrite those paths from the `docker` config with the expected paths.
``` r
config::get(config = "docker")$factset_data_path
#> [1] "/mnt/factset-extracted"
config::get(config = "2022Q4")$factset_data_path
#> [1] "/mnt/factset-extracted"
config::get(config = "2022Q4_azure")$factset_data_path
#> [1] "/mnt/factset-extracted/factset-pacta_timestamp-20221231T000000Z_pulled-20240217T134528Z"
```