### PR TITLE
include `ent_entity_affiliates_last_update` in manifest

### DIFF
--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -883,6 +883,7 @@ parameters <-
     timestamps = list(
       imf_quarter_timestamp = imf_quarter_timestamp,
       factset_data_identifier = factset_timestamp,
+      ent_entity_affiliates_last_update = ent_entity_affiliates_last_update,
       pacta_financial_timestamp = pacta_financial_timestamp
     ),
     scenarios = list(


### PR DESCRIPTION
This was removed in #73 when the FactSet database pulling info was removed, but `ent_entity_affiliates_last_update` is still created above and its value/info is still worthwhile to have in the manifest.