### PR TITLE
copy only needed files to `/workflow.data.preparation/` in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,15 @@ RUN Rscript -e '\
   )) \
   '
 
-COPY .env /.env
-COPY DESCRIPTION /DESCRIPTION
+WORKDIR /workflow.data.preparation
+COPY .env DESCRIPTION ./
 
 RUN Rscript -e '\
   readRenviron(".env"); \
   pak::local_install_deps(); \
   '
 
-COPY . /
+COPY .git/ ./.git/
+COPY config.yml run_pacta_data_preparation.R ./
 
 CMD Rscript run_pacta_data_preparation.R


### PR DESCRIPTION
closes #173 

- moves `WORKDIR /workflow.data.preparation` up so we don't have to keep specifying it
- copies `.env` and `DESCRIPTION` simultaneously
- copies `.git/` separately because I can't figure out if/how to do a multi-copy including a sub-directory
- copies `config.yml` `run_pacta_data_preparation.R` simultaneously

should we also remove the explicit `.dockerignore` @AlexAxthelm?