### PR TITLE
implement `pacta.data.validation`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,7 @@ Imports:
     logger,
     pacta.data.preparation (>= 0.1.0.9003), 
     pacta.data.scraping, 
+    pacta.data.validation,
     pacta.scenario.preparation, 
     readr, 
     rlang, 
@@ -44,6 +45,7 @@ Imports:
 Remotes: 
     RMI-PACTA/pacta.data.preparation, 
     RMI-PACTA/pacta.data.scraping, 
+    RMI-PACTA/pacta.data.validation,
     RMI-PACTA/pacta.scenario.preparation
 Depends: 
     R (>= 3.5.0)

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -313,8 +313,6 @@ financial_data <-
   readRDS(factset_financial_data_path) %>%
   pacta.data.preparation::prepare_financial_data(factset_issue_code_bridge)
 
-pacta.data.validation::validate_financial_data(financial_data)
-
 saveRDS(
   object = financial_data,
   file = file.path(config[["data_prep_outputs_path"]], "financial_data.rds")

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -295,8 +295,8 @@ logger::log_info("Scenario data prepared.")
 # currency data output ---------------------------------------------------------
 
 logger::log_info("Saving file: \"currencies.rds\".")
-pacta.data.validation::validate_currencies(currencies) %>%
-  saveRDS(currencies_data_path)
+pacta.data.validation::validate_currencies(currencies)
+saveRDS(currencies, currencies_data_path)
 
 
 # index_regions output ---------------------------------------------------------

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -443,8 +443,6 @@ abcd_flags_equity <-
     ar_company_id__sectors_with_assets__ownership
   )
 
-pacta.data.validation::validate_abcd_flags_equity(abcd_flags_equity)
-
 saveRDS(
   object = abcd_flags_equity,
   file = file.path(config[["data_prep_outputs_path"]], "abcd_flags_equity.rds")


### PR DESCRIPTION
closes #18

Most validation errors originally found (below) have been resolved. Validation of `financial_data` and `abcd_flags_equity` has been removed for now and will be added in the future.

investigation issues:
- https://github.com/RMI-PACTA/workflow.data.preparation/issues/196
- https://github.com/RMI-PACTA/workflow.data.preparation/issues/197
- https://github.com/RMI-PACTA/workflow.data.preparation/issues/198
- https://github.com/RMI-PACTA/workflow.data.preparation/issues/198

relevant fixes in pacta.data.validation:
- https://github.com/RMI-PACTA/pacta.data.validation/pull/65
- https://github.com/RMI-PACTA/pacta.data.validation/pull/66
- https://github.com/RMI-PACTA/pacta.data.validation/pull/67
- https://github.com/RMI-PACTA/pacta.data.validation/pull/68

relevant fix in pacta.data.preparation
- https://github.com/RMI-PACTA/pacta.data.preparation/pull/18

validation of `financial_data` and `abcd_flags_equity` has been removed from this PR, and future intended implementation is tracked here
- https://github.com/RMI-PACTA/workflow.data.preparation/issues/222
- dependent on https://github.com/RMI-PACTA/pacta.data.validation/issues/69

---

~~currently, a few of the validation checks fail using 2023Q4 config~~
``` r
root_dir <- "~/data/workflow-data-preparation-outputs/2023Q4_20240303T082642Z"

pacta.data.validation::validate_currencies(
  readRDS(file.path(root_dir, "currencies.rds"))
)

pacta.data.validation::validate_financial_data(
  readRDS(file.path(root_dir, "financial_data.rds"))
)
#> Error in base::tryCatch(base::withCallingHandlers({: 1 assertions failed:
#>  * Variable 'data$isin': must contain only valid ISINs, but has
#>  * additional elements "US78467KA#42", "US85255AA*13", "NOR6778@AB29",
#>  * "US048303E#47", "US313855F*48", "US372460A#28", "CA820439A#42",
#>  * "CA008474E@39", "US941848D#79", "US524908@431", "US00253#AB60",
#>  * "US615369A@49", "US893578A@31", "US57555*AD16", "BEB7227*AB60",
#>  * "US031100A@92", "US628464A#60", "US10468*AE44", …, "US758750B*36",
#>  * and "US15135#BQ49".

pacta.data.validation::validate_masterdata_debt_datastore(
  readRDS(file.path(root_dir, "masterdata_debt_datastore.rds"))
)
#> Error in base::tryCatch(base::withCallingHandlers({: 4 assertions failed:
#>  * Variable 'data$technology': must contain only valid technology
#>  * names, but has additional element "ICE Hydrogen_HDV".
#>  * Variable 'data$ald_production_unit': must contain only valid
#>  * production units, but has additional elements "# vehicles", "dwt
#>  * km", "t cement", "t coal", and "t steel".
#>  * Variable 'data$ald_emissions_factor_unit': must contain only valid
#>  * emissions factor units, but has additional elements "tCO2/dwt km",
#>  * "tCO2/km", "tCO2/pkm", "tCO2/tkm", "tCO2e/GJ", "tCO2e/MWh", "tCO2e/t
#>  * cement", "tCO2e/t coal", and "tCO2e/t steel".
#>  * Variable 'data$technology': must contain only valid technology names
#>  * for HDV, but has additional elements %s.

pacta.data.validation::validate_masterdata_ownership_datastore(
  readRDS(file.path(root_dir, "masterdata_ownership_datastore.rds"))
)
#> Error in base::tryCatch(base::withCallingHandlers({: 4 assertions failed:
#>  * Variable 'data$technology': must contain only valid technology
#>  * names, but has additional element "ICE Hydrogen_HDV".
#>  * Variable 'data$ald_production_unit': must contain only valid
#>  * production units, but has additional elements "# vehicles", "dwt
#>  * km", "t cement", "t coal", and "t steel".
#>  * Variable 'data$ald_emissions_factor_unit': must contain only valid
#>  * emissions factor units, but has additional elements "tCO2/dwt km",
#>  * "tCO2/km", "tCO2/pkm", "tCO2/tkm", "tCO2e/GJ", "tCO2e/MWh", "tCO2e/t
#>  * cement", "tCO2e/t coal", and "tCO2e/t steel".
#>  * Variable 'data$technology': must contain only valid technology names
#>  * for HDV, but has additional elements %s.

pacta.data.validation::validate_abcd_flags_bonds(
  readRDS(file.path(root_dir, "abcd_flags_bonds.rds"))
)
#> Error in assert_valid_factset_entity_id(data[[col_name]], add = coll, : Assertion on 'data$credit_parent_id' failed: must contain only valid FactSet entity IDs, but has additional element NA.

pacta.data.validation::validate_abcd_flags_equity(
  readRDS(file.path(root_dir, "abcd_flags_equity.rds"))
)
#> Error in base::tryCatch(base::withCallingHandlers({: 1 assertions failed:
#>  * Variable 'data$isin': must contain only valid ISINs, but has
#>  * additional elements "US78467KA#42", "US85255AA*13", "NOR6778@AB29",
#>  * "US048303E#47", "US313855F*48", "US372460A#28", "CA820439A#42",
#>  * "CA008474E@39", "US941848D#79", "US524908@431", "US00253#AB60",
#>  * "US615369A@49", "US893578A@31", "US57555*AD16", "BEB7227*AB60",
#>  * "US031100A@92", "US628464A#60", "US10468*AE44", …, "US758750B*36",
#>  * and "US15135#BQ49".
```