### PR TITLE
Create add-issues-to-ADO.yml

### DIFF
--- a/.github/workflows/add-issues-to-ADO.yml
+++ b/.github/workflows/add-issues-to-ADO.yml
@@ -21,6 +21,6 @@ jobs:
     name: Run issues workflows
     uses: RMI-PACTA/actions/.github/workflows/issues.yml@main
     with:
-      ado_area_path: "2DegreesInvesting\\Repositories that jdhoffa maintains"
+      ado_area_path: "2DegreesInvesting\\Repositories that cjyetman maintains"
     secrets:
       ADO_TOKEN: ${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/add-issues-to-ADO.yml
+++ b/.github/workflows/add-issues-to-ADO.yml
@@ -1,0 +1,26 @@
+---
+# This example file will enable actions that trigger on created or modified GitHub issues. 
+#
+# Note the @main in `uses:` on the last line. This will call the latest version of the workflow from the `main` branch in the RMI-PACTA/actions repo.
+# You can also specify a tag from that repo, or a commit SHA to pin action versions.
+on:
+  issues:
+    types:
+      [opened, edited, deleted, closed, reopened, labeled, unlabeled, assigned]
+    issue_comment:
+      types: [created, edited, deleted]
+
+name: GH issues
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  issues:
+    name: Run issues workflows
+    uses: RMI-PACTA/actions/.github/workflows/issues.yml@main
+    with:
+      ado_area_path: "2DegreesInvesting\\Repositories that jdhoffa maintains"
+    secrets:
+      ADO_TOKEN: ${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
Create add-issues-to-ADO.yml to automatically create linked tickets in ADO when issues are labeled with `ADO`

I think a new area path "2DegreesInvesting\\Repositories that cjyetman maintains" might need to be setup in ADO before this works?