### PR TITLE
Add `source_scenario_pairs`, `scenario_geographies`, and `equity_markets` to manifest

### DIFF
--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -828,6 +828,24 @@ source_scenario_pairs <-
   dplyr::distinct() %>%
   dplyr::arrange(.data[["scenario_source"]], .data[["scenario"]])
 
+scenario_geographies <-
+  dplyr::bind_rows(
+    equity_abcd_scenario,
+    bonds_abcd_scenario
+  ) %>%
+  dplyr::select("scenario_geography") %>%
+  dplyr::distinct() %>%
+  dplyr::arrange(.data[["scenario_geography"]])
+
+equity_markets <-
+  dplyr::bind_rows(
+    equity_abcd_scenario,
+    bonds_abcd_scenario
+  ) %>%
+  dplyr::select("equity_market") %>%
+  dplyr::distinct() %>%
+  dplyr::arrange(.data[["equity_market"]])
+
 rm(equity_abcd_scenario)
 rm(bonds_abcd_scenario)
 invisible(gc())
@@ -869,7 +887,9 @@ parameters <-
     package_news = package_news,
     output_stats = list(
       sector_tech_pairs = sector_tech_pairs,
-      source_scenario_pairs = source_scenario_pairs
+      source_scenario_pairs = source_scenario_pairs,
+      scenario_geographies = scenario_geographies,
+      equity_markets = equity_markets
     )
   )
 

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -804,7 +804,7 @@ package_news <-
     USE.NAMES = TRUE
   )
 
-# report sector-technology pairs present in output data
+# report sector-technology and source-scenario pairs present in output data
 equity_abcd_scenario <-
   readRDS(file.path(config[["data_prep_outputs_path"]], "equity_abcd_scenario.rds"))
 bonds_abcd_scenario <-
@@ -819,10 +819,20 @@ sector_tech_pairs <-
   dplyr::distinct() %>%
   dplyr::arrange(.data[["ald_sector"]], .data[["technology"]])
 
+source_scenario_pairs <-
+  dplyr::bind_rows(
+    equity_abcd_scenario,
+    bonds_abcd_scenario
+  ) %>%
+  dplyr::select("scenario_source", "scenario") %>%
+  dplyr::distinct() %>%
+  dplyr::arrange(.data[["scenario_source"]], .data[["scenario"]])
+
 rm(equity_abcd_scenario)
 rm(bonds_abcd_scenario)
 invisible(gc())
 
+# build parameters output object
 parameters <-
   list(
     config_name = config_name,
@@ -858,7 +868,8 @@ parameters <-
     ),
     package_news = package_news,
     output_stats = list(
-      sector_tech_pairs = sector_tech_pairs
+      sector_tech_pairs = sector_tech_pairs,
+      source_scenario_pairs = source_scenario_pairs
     )
   )
 

--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -810,44 +810,41 @@ equity_abcd_scenario <-
 bonds_abcd_scenario <-
   readRDS(file.path(config[["data_prep_outputs_path"]], "bonds_abcd_scenario.rds"))
 
-sector_tech_pairs <-
+abcd_scenario <-
   dplyr::bind_rows(
     equity_abcd_scenario,
     bonds_abcd_scenario
-  ) %>%
+  )
+
+rm(equity_abcd_scenario)
+rm(bonds_abcd_scenario)
+invisible(gc())
+
+sector_tech_pairs <-
+  abcd_scenario %>%
   dplyr::select("ald_sector", "technology") %>%
   dplyr::distinct() %>%
   dplyr::arrange(.data[["ald_sector"]], .data[["technology"]])
 
 source_scenario_pairs <-
-  dplyr::bind_rows(
-    equity_abcd_scenario,
-    bonds_abcd_scenario
-  ) %>%
+  abcd_scenario %>%
   dplyr::select("scenario_source", "scenario") %>%
   dplyr::distinct() %>%
   dplyr::arrange(.data[["scenario_source"]], .data[["scenario"]])
 
 scenario_geographies <-
-  dplyr::bind_rows(
-    equity_abcd_scenario,
-    bonds_abcd_scenario
-  ) %>%
+  abcd_scenario %>%
   dplyr::select("scenario_geography") %>%
   dplyr::distinct() %>%
   dplyr::arrange(.data[["scenario_geography"]])
 
 equity_markets <-
-  dplyr::bind_rows(
-    equity_abcd_scenario,
-    bonds_abcd_scenario
-  ) %>%
+  abcd_scenario %>%
   dplyr::select("equity_market") %>%
   dplyr::distinct() %>%
   dplyr::arrange(.data[["equity_market"]])
 
-rm(equity_abcd_scenario)
-rm(bonds_abcd_scenario)
+rm(abcd_scenario)
 invisible(gc())
 
 # build parameters output object


### PR DESCRIPTION
Add additional info relevant to setting parameters in workflow.transition.monitor configs to the manifest: `source_scenario_pairs`, `scenario_geographies`, and `equity_markets`