### PR TITLE
default `export_archives` to `FALSE`

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -17,7 +17,7 @@ default:
   factset_manual_pacta_sector_override_filename: ""  # a single filename of the intended factset_manual_pacta_sector_override RDS (must exist in the `factset_data_path` directory)
   update_currencies: TRUE  # a single `TRUE` or `FALSE` specifying whether currency data should be pulled on-the-fly (or a previously pulled version should be used)
   export_sqlite_files: TRUE  # a single `TRUE` or `FALSE` specifying whether sqlite versions of some output files should be included in the outputs
-  export_archives: TRUE # Boolean: Export zip archives of input files and output files?
+  export_archives: FALSE # Boolean: Export zip archives of input files and output files?
   imf_quarter_timestamp: ""  # a single string specifying the IMF quarter timestamp (for pulling of currency data) in the form "YYYY-QX", e.g. "2021-Q4"
   pacta_financial_timestamp: ""  # a single string specifying the PACTA quarter timestamp in the form "YYYYQX", e.g. "2021Q4"
   market_share_target_reference_year: 0  # a single integer specifying the market share target reference year in the form YYYY, e.g. 2021
@@ -136,6 +136,7 @@ docker:
 
 2022Q4_azure:
   inherits: 2022Q4
+  export_archives: TRUE
   data_prep_outputs_path: "/mnt/outputs"
   asset_impact_data_path: "/mnt/asset-impact"
   factset_data_path: "/mnt/factset-extracted/factset-pacta_timestamp-20221231T000000Z_pulled-20240217T134528Z"
@@ -176,6 +177,7 @@ docker:
 
 2023Q4_azure:
   inherits: 2023Q4
+  export_archives: TRUE
   data_prep_outputs_path: "/mnt/outputs"
   asset_impact_data_path: "/mnt/asset-impact/2024-02-15_AI_RMI_2023Q4"
   factset_data_path: "/mnt/factset-extracted/factset-pacta_timestamp-20231231T000000Z_pulled-20240229T181710Z"


### PR DESCRIPTION
Since exporting the archives is very expensive (time and memory), I'm setting this default to `FALSE` and explicitly opting-in for the azure configs (where it is generally desired).