### PR TITLE
remove version specification from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   data_prep:
     build:


### PR DESCRIPTION
It is obsolete 
https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-optional