### PR TITLE
remove read of `.env`

### DIFF
--- a/run_pacta_data_preparation.R
+++ b/run_pacta_data_preparation.R
@@ -20,8 +20,6 @@ suppressPackageStartupMessages({
 
 # config -----------------------------------------------------------------------
 
-if (Sys.getenv("R_CONFIG_ACTIVE") != "desktop") { readRenviron(".env") }
-
 config_name <- Sys.getenv("R_CONFIG_ACTIVE")
 raw_config <-
   config::get(


### PR DESCRIPTION
`.env` file is no longer copied into Docker image as of #217

docker compose sets appropriate shell environment variables, and those can be/are read in with e.g. `Sys.getenv("R_CONFIG_ACTIVE")`