### PR TITLE
update config to gain new `weo_2023` scenarios

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -185,4 +185,4 @@ docker:
   data_prep_outputs_path: "/mnt/outputs"
   asset_impact_data_path: "/mnt/asset-impact/2024-02-15_AI_RMI_2023Q4"
   factset_data_path: "/mnt/factset-extracted/factset-pacta_timestamp-20231231T000000Z_pulled-20240524T132816Z"
-  scenarios_data_path: "/mnt/workflow-scenario-preparation-outputs/2023Q4_20240416_T140550Z"
+  scenarios_data_path: "/mnt/workflow-scenario-preparation-outputs/2023Q4_20240628_T121351Z"


### PR DESCRIPTION
... for steel cement and aviation.

Update `2023Q4` data prep config to pick-up the latest run of scenario preparation, which now includes new scenarios `APS` and `STEPS` for the sectors steel, cement and aviation, for the `WEO2023` scenario. 

Relates to https://github.com/RMI-PACTA/pacta.scenario.data.preparation/pull/61