### PR TITLE
config: update 2023Q4 scenario preparation config path

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -39,7 +39,7 @@ desktop:
   data_prep_outputs_path: "~/data/pactadatadev/workflow-data-preparation-outputs"
   asset_impact_data_path: "~/data/pactarawdata/asset-impact/2024-02-15_AI_RMI_2023Q4"
   factset_data_path: "~/data/pactarawdata/factset-extracted/factset-pacta_timestamp-20231231T000000Z_pulled-20240524T132816Z"
-  scenarios_data_path: "~/data/pactadatadev/workflow-scenario-preparation-outputs/2023Q4_20240628_T121351Z"
+  scenarios_data_path: "~/data/pactadatadev/workflow-scenario-preparation-outputs/2023Q4_20240701_T105302Z"
 
 docker:
   data_prep_outputs_path: "/mnt/outputs"
@@ -185,4 +185,4 @@ docker:
   data_prep_outputs_path: "/mnt/outputs"
   asset_impact_data_path: "/mnt/asset-impact/2024-02-15_AI_RMI_2023Q4"
   factset_data_path: "/mnt/factset-extracted/factset-pacta_timestamp-20231231T000000Z_pulled-20240524T132816Z"
-  scenarios_data_path: "/mnt/workflow-scenario-preparation-outputs/2023Q4_20240628_T121351Z"
+  scenarios_data_path: "/mnt/workflow-scenario-preparation-outputs/2023Q4_20240701_T105302Z"


### PR DESCRIPTION
The initial scenario preparation configuration bump that was committed in #236 and #237 pointed to a scenario preparation output that was missing crucial data. 

The data was missing due to a bug that was introduced in: https://github.com/RMI-PACTA/pacta.scenario.data.preparation/pull/61

and later solved by:
https://github.com/RMI-PACTA/pacta.scenario.data.preparation/pull/63

The new scenario preparation outputs, in the directory:  `2023Q4_20240701_T105302Z`

which can be found here: https://pactadatadev.file.core.windows.net/workflow-scenario-preparation-outputs/2023Q4_20240701_T105302Z

contain all the expected output datasets.