### PR TITLE
reserve appropriate amount of RAM in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,7 @@ services:
       - type: bind
         source: ${HOST_OUTPUTS_PATH}
         target: /mnt/outputs
+    deploy:
+      resources:
+        reservations:
+          memory: 14gb


### PR DESCRIPTION
Use the docker-compose file to specify a minimum amount of RAM needed to run the process to avoid problems stemming from attempting to run the process with an externally fixed amount of RAM below what is needed https://docs.docker.com/compose/compose-file/deploy/#memory